### PR TITLE
feat: Component 2+3 — preprocessing pipeline and MLflow tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ data/processed/*
 data/splits/*
 !data/splits/.gitkeep
 !data/splits/*.dvc
+!data/splits/metrics.json
 
 # Models & artifacts
 *.pkl

--- a/configs/params.yaml
+++ b/configs/params.yaml
@@ -53,3 +53,5 @@ mlflow:
 
 validation:
   min_test_r2: 0.70
+  # CI model-validation: require test RMSE to stay below this ceiling (from committed metrics.json)
+  rmse_threshold: 80.0

--- a/data/splits/metrics.json
+++ b/data/splits/metrics.json
@@ -1,0 +1,17 @@
+{
+  "best_cv_rmse": 64.39162362496543,
+  "best_params": {
+    "max_depth": null,
+    "min_samples_leaf": 1,
+    "n_estimators": 200
+  },
+  "gate": {
+    "min_test_r2": 0.7,
+    "passed": true
+  },
+  "test": {
+    "mae": 45.0629244170033,
+    "r2": 0.7570725279289972,
+    "rmse": 66.71144693740244
+  }
+}

--- a/dvc.lock
+++ b/dvc.lock
@@ -5,16 +5,16 @@ stages:
     deps:
     - path: configs/params.yaml
       hash: md5
-      md5: d49ed3ffeca47852985a5f18067cee09
-      size: 1393
+      md5: 7a79abaf777b7f6a49fa8df268928c33
+      size: 1516
     - path: data/raw/hour.csv
       hash: md5
       md5: d50bd5a6f55131e72a7bedc334e2fce1
       size: 1156736
     - path: src/config.py
       hash: md5
-      md5: a675cc46c728bc268212d0910aa70131
-      size: 1715
+      md5: ca61986843ad5b749b6a1e5a1add2720
+      size: 1741
     - path: src/data/load.py
       hash: md5
       md5: e0eb44474a56688f25886be034a4ff3b
@@ -30,23 +30,23 @@ stages:
     outs:
     - path: data/processed/bike_clean.parquet
       hash: md5
-      md5: 11da264e5704816109d8c72f2943eb14
-      size: 92464
+      md5: d0b59acb7d5653e35d754ef01eaa039a
+      size: 93550
   preprocess:
     cmd: python -m src.data.split
     deps:
     - path: configs/params.yaml
       hash: md5
-      md5: d49ed3ffeca47852985a5f18067cee09
-      size: 1393
+      md5: 7a79abaf777b7f6a49fa8df268928c33
+      size: 1516
     - path: data/processed/bike_clean.parquet
       hash: md5
-      md5: 11da264e5704816109d8c72f2943eb14
-      size: 92464
+      md5: d0b59acb7d5653e35d754ef01eaa039a
+      size: 93550
     - path: src/config.py
       hash: md5
-      md5: a675cc46c728bc268212d0910aa70131
-      size: 1715
+      md5: ca61986843ad5b749b6a1e5a1add2720
+      size: 1741
     - path: src/data/split.py
       hash: md5
       md5: f468a3fa37c2e40e8135e07e057f0d7e
@@ -54,45 +54,89 @@ stages:
     outs:
     - path: data/splits/production.parquet
       hash: md5
-      md5: 20ea77feea8544b7b320a84c88626e97
-      size: 126017
+      md5: 5fc3539850693ee657235e088549f3b6
+      size: 127117
     - path: data/splits/reference.parquet
       hash: md5
-      md5: d7308e5f93450992cc2a8b686ebee57b
-      size: 16161
+      md5: 2103a51ea5a39c418b91f0e994c1c6d2
+      size: 17252
     - path: data/splits/test.parquet
       hash: md5
-      md5: 67838cf1ba2f55a30a916219e958a6da
-      size: 20905
+      md5: 714f5f6220f8e7d20da7cb0d14d5e5f8
+      size: 22003
     - path: data/splits/train.parquet
       hash: md5
-      md5: e138c71390b04ad5dd5c9a6a21ede0b2
-      size: 52015
+      md5: 6224f2f9fc0357d6707091fe906a5884
+      size: 53139
   featurize:
     cmd: python -m src.features.featurize
     deps:
     - path: configs/params.yaml
       hash: md5
-      md5: d49ed3ffeca47852985a5f18067cee09
-      size: 1393
+      md5: 7a79abaf777b7f6a49fa8df268928c33
+      size: 1516
     - path: data/splits/train.parquet
       hash: md5
-      md5: e138c71390b04ad5dd5c9a6a21ede0b2
-      size: 52015
+      md5: 6224f2f9fc0357d6707091fe906a5884
+      size: 53139
     - path: src/config.py
       hash: md5
-      md5: a675cc46c728bc268212d0910aa70131
-      size: 1715
+      md5: ca61986843ad5b749b6a1e5a1add2720
+      size: 1741
     - path: src/features/featurize.py
       hash: md5
-      md5: 932bd407a079b294cb4c2bbbb1c758f1
-      size: 859
+      md5: 19e1619ea06937814b8d61a942e97fb5
+      size: 861
     - path: src/features/preprocessor.py
       hash: md5
-      md5: 9f4094b2955481915b5ebd403e69bac8
+      md5: 09fc21c9c556d2cf77071fa198364225
       size: 1640
     outs:
     - path: data/splits/preprocessor.pkl
       hash: md5
-      md5: e5ae8e19cf2fbd6cec6645eecd50ddd3
-      size: 4466
+      md5: a2c6ea9e2d3804957a656dea16293080
+      size: 4623
+  train:
+    cmd: python -m src.training.train
+    deps:
+    - path: configs/params.yaml
+      hash: md5
+      md5: 7a79abaf777b7f6a49fa8df268928c33
+      size: 1516
+    - path: data/splits/preprocessor.pkl
+      hash: md5
+      md5: a2c6ea9e2d3804957a656dea16293080
+      size: 4623
+    - path: data/splits/test.parquet
+      hash: md5
+      md5: 714f5f6220f8e7d20da7cb0d14d5e5f8
+      size: 22003
+    - path: data/splits/train.parquet
+      hash: md5
+      md5: 6224f2f9fc0357d6707091fe906a5884
+      size: 53139
+    - path: src/config.py
+      hash: md5
+      md5: ca61986843ad5b749b6a1e5a1add2720
+      size: 1741
+    - path: src/evaluation/metrics.py
+      hash: md5
+      md5: 26877215441461f21e99b85fffb8f3c3
+      size: 385
+    - path: src/features/preprocessor.py
+      hash: md5
+      md5: 09fc21c9c556d2cf77071fa198364225
+      size: 1640
+    - path: src/training/hpo.py
+      hash: md5
+      md5: e5b9e4a29a736d6ff301392dd42abe9e
+      size: 2176
+    - path: src/training/train.py
+      hash: md5
+      md5: b70bbf473b46cddce02d968fcadab364
+      size: 5635
+    outs:
+    - path: data/splits/model.pkl
+      hash: md5
+      md5: 44d8b41825ab9e8e8960230a086b39f6
+      size: 108505633

--- a/dvc.yaml
+++ b/dvc.yaml
@@ -34,3 +34,18 @@
       - configs/params.yaml
     outs:
       - data/splits/preprocessor.pkl
+
+  train:
+    cmd: python -m src.training.train
+    deps:
+      - data/splits/train.parquet
+      - data/splits/test.parquet
+      - data/splits/preprocessor.pkl
+      - src/training/train.py
+      - src/training/hpo.py
+      - src/evaluation/metrics.py
+      - src/features/preprocessor.py
+      - src/config.py
+      - configs/params.yaml
+    outs:
+      - data/splits/model.pkl

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
-﻿[project]
+[project]
 name = "mlops-final"
 version = "0.1.0"
 requires-python = ">=3.11,<3.13"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,8 @@
 [pytest]
 testpaths = tests
-pythonpath = src
+pythonpath =
+    .
+    src
 addopts = -ra -q --strict-markers
 filterwarnings =
     ignore::DeprecationWarning

--- a/scripts/compute_subgroup_metrics.py
+++ b/scripts/compute_subgroup_metrics.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Sequence
+from pathlib import Path
+
+import joblib
+import pandas as pd
+from src.config import load_config
+from src.evaluation.metrics import compute_metrics
+
+GROUP_FIELDS = ["season", "weathersit", "workingday"]
+MIN_GROUP_N = 30
+OUTPUT_PATH = Path("docs") / "subgroup_metrics.json"
+
+
+def feature_columns(cfg) -> list[str]:
+    return cfg.data.numeric_features + cfg.data.categorical_features
+
+
+def build_subgroup_payload(
+    df: pd.DataFrame,
+    y_true: Sequence[float],
+    y_pred: Sequence[float],
+    group_fields: Sequence[str] = GROUP_FIELDS,
+    min_n: int = MIN_GROUP_N,
+) -> dict:
+    scored = df.copy()
+    scored["_y_true"] = list(y_true)
+    scored["_y_pred"] = list(y_pred)
+
+    payload = {
+        "overall": compute_metrics(scored["_y_true"], scored["_y_pred"]),
+        "subgroups": {},
+    }
+
+    for field in group_fields:
+        field_groups = []
+        for value, group in scored.groupby(field, sort=True):
+            n = int(len(group))
+            if n < min_n:
+                continue
+            metrics = compute_metrics(group["_y_true"], group["_y_pred"])
+            field_groups.append({
+                "value": value.item() if hasattr(value, "item") else value,
+                "n": n,
+                **metrics,
+            })
+        payload["subgroups"][field] = field_groups
+
+    return payload
+
+
+def write_subgroup_metrics(payload: dict, output_path: Path = OUTPUT_PATH) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def compute_and_write_subgroup_metrics(output_path: Path = OUTPUT_PATH) -> dict:
+    cfg = load_config()
+    model = joblib.load(cfg.paths.model)
+    preprocessor = joblib.load(cfg.paths.preprocessor)
+    test = pd.read_parquet(cfg.paths.test)
+
+    X_test = test[feature_columns(cfg)]
+    y_true = test[cfg.data.target]
+    y_pred = model.predict(preprocessor.transform(X_test))
+
+    payload = build_subgroup_payload(test, y_true, y_pred)
+    write_subgroup_metrics(payload, output_path)
+    print(f"saved subgroup metrics to {output_path}")
+    return payload
+
+
+def main() -> int:
+    compute_and_write_subgroup_metrics()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/export_runs.py
+++ b/scripts/export_runs.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import mlflow
+import pandas as pd
+from src.config import load_config
+
+OUTPUT_PATH = Path("docs") / "experiment_log.csv"
+
+
+def resolve_tracking_uri(configured_uri: str) -> str:
+    return os.environ.get("MLFLOW_TRACKING_URI") or configured_uri
+
+
+def write_experiment_log(runs: pd.DataFrame, output_path: Path = OUTPUT_PATH) -> int:
+    if runs.empty:
+        raise ValueError("No runs found to export")
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    runs.to_csv(output_path, index=False)
+    return len(runs)
+
+
+def export_runs(output_path: Path = OUTPUT_PATH) -> int:
+    cfg = load_config()
+    tracking_uri = resolve_tracking_uri(cfg.mlflow.tracking_uri)
+    mlflow.set_tracking_uri(tracking_uri)
+    experiment = mlflow.get_experiment_by_name(cfg.mlflow.experiment_name)
+    if experiment is None:
+        raise ValueError(f"Experiment not found: {cfg.mlflow.experiment_name}")
+
+    runs = mlflow.search_runs(
+        experiment_ids=[experiment.experiment_id],
+        output_format="pandas",
+    )
+    row_count = write_experiment_log(runs, output_path)
+    print(f"exported {row_count} runs to {output_path}")
+    return row_count
+
+
+def main() -> int:
+    try:
+        export_runs()
+    except ValueError as exc:
+        print(f"export_runs: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/config.py
+++ b/src/config.py
@@ -67,6 +67,7 @@ class MLflowCfg(BaseModel):
 
 class ValidationCfg(BaseModel):
     min_test_r2: float
+    rmse_threshold: float
 
 
 class Config(BaseModel):

--- a/src/evaluation/metrics.py
+++ b/src/evaluation/metrics.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import numpy as np
+from sklearn.metrics import mean_absolute_error, mean_squared_error, r2_score
+
+
+def compute_metrics(y_true, y_pred) -> dict[str, float]:
+    return {
+        "rmse": float(np.sqrt(mean_squared_error(y_true, y_pred))),
+        "mae": float(mean_absolute_error(y_true, y_pred)),
+        "r2": float(r2_score(y_true, y_pred)),
+    }

--- a/src/training/hpo.py
+++ b/src/training/hpo.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+import mlflow
+import numpy as np
+import optuna
+from sklearn.ensemble import RandomForestRegressor
+from sklearn.model_selection import cross_val_score
+from sklearn.pipeline import Pipeline
+
+
+@dataclass(frozen=True)
+class HPOResult:
+    best_params: dict[str, Any]
+    best_cv_rmse: float
+    study: optuna.Study
+
+
+def run_hpo(
+    X,
+    y,
+    search_space: dict[str, list[Any]],
+    n_trials: int,
+    cv_folds: int,
+    random_state: int = 42,
+    preprocessor_factory: Callable[[], Any] | None = None,
+) -> HPOResult:
+    sampler = optuna.samplers.TPESampler(seed=random_state)
+    study = optuna.create_study(direction="minimize", sampler=sampler)
+
+    def objective(trial: optuna.Trial) -> float:
+        trial_params = {
+            name: trial.suggest_categorical(name, choices)
+            for name, choices in search_space.items()
+        }
+        model = RandomForestRegressor(
+            **trial_params,
+            n_jobs=-1,
+            random_state=random_state,
+        )
+        estimator = model
+        if preprocessor_factory is not None:
+            estimator = Pipeline([
+                ("preprocessor", preprocessor_factory()),
+                ("model", model),
+            ])
+        scores = cross_val_score(
+            estimator,
+            X,
+            y,
+            cv=cv_folds,
+            scoring="neg_mean_squared_error",
+            n_jobs=None,
+        )
+        cv_rmse = float(np.sqrt(-scores.mean()))
+
+        logged_params = {
+            **trial_params,
+            "n_jobs": -1,
+            "random_state": random_state,
+        }
+        with mlflow.start_run(run_name=f"hpo_trial_{trial.number}", nested=True):
+            mlflow.log_params(logged_params)
+            mlflow.log_metrics({"cv_rmse": cv_rmse})
+            mlflow.log_metric("cv_rmse_step", cv_rmse, step=trial.number)
+
+        return cv_rmse
+
+    study.optimize(objective, n_trials=n_trials)
+    return HPOResult(
+        best_params=dict(study.best_params),
+        best_cv_rmse=float(study.best_value),
+        study=study,
+    )

--- a/src/training/registry.py
+++ b/src/training/registry.py
@@ -1,0 +1,682 @@
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import warnings
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+MLFLOW_SEARCH_MAX_RESULTS = 50_000
+
+
+@dataclass(frozen=True)
+class ModelRunCandidate:
+    run_id: str
+    test_r2: float
+    test_rmse: float
+    metrics: dict[str, Any]
+    params: dict[str, Any]
+    status: str | None = None
+    tags: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class RegistrationResult:
+    candidate: ModelRunCandidate
+    model_name: str
+    version: Any
+    created: bool
+
+
+@dataclass(frozen=True)
+class ModelVersionSummary:
+    version: str
+    run_id: str | None
+    metrics: dict[str, float]
+    current_stage: str | None = None
+
+
+@dataclass(frozen=True)
+class PromotionDecision:
+    candidate: ModelVersionSummary
+    current_production: ModelVersionSummary | None
+    should_promote: bool
+    compare_status: str
+    safety_notes: list[str]
+    risk_notes: list[str]
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _resolve_tracking_uri(configured_uri: str) -> str:
+    return os.environ.get("MLFLOW_TRACKING_URI") or configured_uri
+
+
+def _as_finite_float(value: Any) -> float | None:
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(numeric):
+        return None
+    return numeric
+
+
+def _strip_prefixed_values(row: Mapping[str, Any], prefix: str) -> dict[str, Any]:
+    return {
+        key.removeprefix(prefix): value
+        for key, value in row.items()
+        if isinstance(key, str) and key.startswith(prefix)
+    }
+
+
+def _mapping_candidate(row: Mapping[str, Any]) -> ModelRunCandidate | None:
+    run_id = row.get("run_id") or row.get("info.run_id") or row.get("run.info.run_id")
+    if run_id is None:
+        return None
+
+    metrics = dict(row.get("metrics") or {})
+    metrics.update(_strip_prefixed_values(row, "metrics."))
+    for key in ("test_r2", "test_rmse"):
+        if key in row and key not in metrics:
+            metrics[key] = row[key]
+
+    params = dict(row.get("params") or {})
+    params.update(_strip_prefixed_values(row, "params."))
+    if "validation_passed" in row and "validation_passed" not in params:
+        params["validation_passed"] = row["validation_passed"]
+
+    tags = dict(row.get("tags") or {})
+    tags.update(_strip_prefixed_values(row, "tags."))
+    status = row.get("status") or row.get("info.status") or row.get("run.info.status")
+
+    return _build_candidate(str(run_id), metrics, params, status=status, tags=tags)
+
+
+def _mlflow_run_candidate(run: Any) -> ModelRunCandidate | None:
+    run_info = getattr(run, "info", None)
+    run_data = getattr(run, "data", None)
+    run_id = getattr(run_info, "run_id", None)
+    if run_id is None:
+        run_id = getattr(run, "run_id", None)
+    if run_id is None:
+        return None
+
+    metrics = dict(getattr(run_data, "metrics", None) or getattr(run, "metrics", None) or {})
+    params = dict(getattr(run_data, "params", None) or getattr(run, "params", None) or {})
+    tags = dict(getattr(run_data, "tags", None) or getattr(run, "tags", None) or {})
+    status = getattr(run_info, "status", None) or getattr(run, "status", None)
+    return _build_candidate(str(run_id), metrics, params, status=status, tags=tags)
+
+
+def _build_candidate(
+    run_id: str,
+    metrics: Mapping[str, Any],
+    params: Mapping[str, Any],
+    status: Any = None,
+    tags: Mapping[str, Any] | None = None,
+) -> ModelRunCandidate | None:
+    test_r2 = _as_finite_float(metrics.get("test_r2"))
+    test_rmse = _as_finite_float(metrics.get("test_rmse"))
+    if test_r2 is None or test_rmse is None:
+        return None
+    return ModelRunCandidate(
+        run_id=run_id,
+        test_r2=test_r2,
+        test_rmse=test_rmse,
+        metrics=dict(metrics),
+        params=dict(params),
+        status=str(status) if status is not None else None,
+        tags=dict(tags or {}),
+    )
+
+
+def _to_candidate(run: Any) -> ModelRunCandidate | None:
+    if isinstance(run, ModelRunCandidate):
+        return _build_candidate(run.run_id, run.metrics, run.params, status=run.status, tags=run.tags)
+    if isinstance(run, Mapping):
+        return _mapping_candidate(run)
+    return _mlflow_run_candidate(run)
+
+
+def _iter_run_records(runs: Any) -> Iterable[Any]:
+    if hasattr(runs, "to_dict"):
+        return runs.to_dict(orient="records")
+    return runs
+
+
+def _normalized_validation_key(key: Any) -> str:
+    return str(key).lower().replace(".", "_").replace("-", "_")
+
+
+def _validation_passed_value(candidate: ModelRunCandidate) -> Any | None:
+    for values in (candidate.params, candidate.tags):
+        for key, value in values.items():
+            normalized_key = _normalized_validation_key(key)
+            if normalized_key in {"validation_passed", "gate_passed"}:
+                return value
+    return None
+
+
+def _is_validation_passed(value: Any) -> bool:
+    return value is True or (isinstance(value, str) and value.lower() == "true")
+
+
+def _is_candidate_eligible(
+    candidate: ModelRunCandidate,
+    min_test_r2: float | None = None,
+) -> bool:
+    if candidate.status is not None and candidate.status.upper() != "FINISHED":
+        return False
+
+    validation_passed = _validation_passed_value(candidate)
+    if validation_passed is not None and not _is_validation_passed(validation_passed):
+        return False
+
+    if min_test_r2 is not None and candidate.test_r2 < min_test_r2:
+        return False
+
+    return True
+
+
+def select_best_run(
+    runs: Iterable[Any],
+    min_test_r2: float | None = None,
+) -> ModelRunCandidate | None:
+    candidates = [
+        candidate
+        for candidate in (_to_candidate(run) for run in _iter_run_records(runs))
+        if candidate is not None and _is_candidate_eligible(candidate, min_test_r2)
+    ]
+    if not candidates:
+        return None
+    return min(candidates, key=lambda candidate: (-candidate.test_r2, candidate.test_rmse, candidate.run_id))
+
+
+def find_best_model_run(
+    client: Any,
+    experiment_name: str,
+    max_results: int = MLFLOW_SEARCH_MAX_RESULTS,
+    *,
+    min_test_r2: float | None = None,
+) -> ModelRunCandidate:
+    experiment = client.get_experiment_by_name(experiment_name)
+    if experiment is None:
+        raise ValueError(f"MLflow experiment not found: {experiment_name}")
+
+    runs = client.search_runs(
+        experiment_ids=[experiment.experiment_id],
+        max_results=min(max_results, MLFLOW_SEARCH_MAX_RESULTS),
+    )
+    candidate = select_best_run(runs, min_test_r2=min_test_r2)
+    if candidate is None:
+        raise RuntimeError(f"No eligible model runs found for experiment: {experiment_name}")
+    return candidate
+
+
+def _is_already_exists_error(exc: Exception) -> bool:
+    error_code = getattr(exc, "error_code", None)
+    return error_code == "RESOURCE_ALREADY_EXISTS" or "already exists" in str(exc).lower()
+
+
+def _create_registered_model_if_needed(client: Any, model_name: str) -> None:
+    from mlflow.exceptions import MlflowException
+
+    try:
+        client.create_registered_model(model_name)
+    except MlflowException as exc:
+        if not _is_already_exists_error(exc):
+            raise
+
+
+def register_candidate_model(client: Any, candidate: ModelRunCandidate, model_name: str) -> Any:
+    _create_registered_model_if_needed(client, model_name)
+    source = f"runs:/{candidate.run_id}/model"
+    version = client.create_model_version(
+        name=model_name,
+        source=source,
+        run_id=candidate.run_id,
+    )
+    tags = {
+        "run_id": candidate.run_id,
+        "source_run_id": candidate.run_id,
+        "test_r2": str(candidate.test_r2),
+        "test_rmse": str(candidate.test_rmse),
+    }
+    tags.update(
+        {f"metric.{key}": str(candidate.metrics[key]) for key in sorted(candidate.metrics)}
+    )
+    tags.update(
+        {f"param.{key}": str(candidate.params[key]) for key in sorted(candidate.params)}
+    )
+    for key, value in tags.items():
+        client.set_model_version_tag(model_name, version.version, key, value)
+    return version
+
+
+def _find_existing_model_version_for_run(client: Any, model_name: str, run_id: str) -> Any | None:
+    source = f"runs:/{run_id}/model"
+    versions = client.search_model_versions(f"name = '{model_name}'")
+    for version in sorted(versions, key=lambda item: str(getattr(item, "version", ""))):
+        tags = getattr(version, "tags", None) or {}
+        if getattr(version, "run_id", None) == run_id:
+            return version
+        if getattr(version, "source", None) == source:
+            return version
+        if tags.get("run_id") == run_id or tags.get("source_run_id") == run_id:
+            return version
+    return None
+
+
+def _version_number(version: Any) -> int:
+    try:
+        return int(getattr(version, "version", version))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _version_str(version: Any) -> str:
+    return str(getattr(version, "version", version))
+
+
+def _model_version_metric(version: Any, key: str) -> float | None:
+    tags = getattr(version, "tags", None) or {}
+    for candidate_key in (key, f"metric.{key}", f"metrics.{key}"):
+        metric = _as_finite_float(tags.get(candidate_key))
+        if metric is not None:
+            return metric
+    return None
+
+
+def _run_metrics(client: Any | None, run_id: str | None) -> dict[str, float]:
+    if client is None or run_id is None:
+        return {}
+    try:
+        run = client.get_run(run_id)
+    except Exception:
+        return {}
+    run_data = getattr(run, "data", None)
+    metrics = getattr(run_data, "metrics", None) or getattr(run, "metrics", None) or {}
+    return {
+        key: metric
+        for key in ("test_r2", "test_rmse")
+        if (metric := _as_finite_float(metrics.get(key))) is not None
+    }
+
+
+def _model_version_summary(version: Any, client: Any | None = None) -> ModelVersionSummary:
+    metrics = {
+        key: metric
+        for key in ("test_r2", "test_rmse")
+        if (metric := _model_version_metric(version, key)) is not None
+    }
+    if len(metrics) < 2:
+        metrics.update(_run_metrics(client, getattr(version, "run_id", None)))
+    return ModelVersionSummary(
+        version=_version_str(version),
+        run_id=getattr(version, "run_id", None),
+        metrics=metrics,
+        current_stage=getattr(version, "current_stage", None),
+    )
+
+
+def find_current_production_version(client: Any, model_name: str) -> Any | None:
+    versions = client.search_model_versions(f"name = '{model_name}'")
+    production_versions = [
+        version
+        for version in versions
+        if getattr(version, "current_stage", None) == "Production"
+    ]
+    if not production_versions:
+        return None
+    return max(production_versions, key=_version_number)
+
+
+def build_promotion_decision(
+    *,
+    candidate: ModelRunCandidate,
+    candidate_version: Any,
+    min_test_r2: float,
+    current_production: Any | None,
+    client: Any | None = None,
+) -> PromotionDecision:
+    candidate_summary = ModelVersionSummary(
+        version=_version_str(candidate_version),
+        run_id=candidate.run_id,
+        metrics={"test_r2": candidate.test_r2, "test_rmse": candidate.test_rmse},
+        current_stage=getattr(candidate_version, "current_stage", None),
+    )
+    safety_notes: list[str] = []
+    risk_notes: list[str] = []
+
+    if candidate.test_r2 < min_test_r2:
+        risk_notes.append(
+            f"Candidate test_r2={candidate.test_r2:.6f} is below promotion gate {min_test_r2:.6f}."
+        )
+        return PromotionDecision(
+            candidate=candidate_summary,
+            current_production=_model_version_summary(current_production, client)
+            if current_production is not None
+            else None,
+            should_promote=False,
+            compare_status="below_min_test_r2",
+            safety_notes=safety_notes,
+            risk_notes=risk_notes,
+        )
+
+    safety_notes.append(
+        f"Candidate passes min_test_r2 gate: {candidate.test_r2:.6f} >= {min_test_r2:.6f}."
+    )
+
+    if current_production is None:
+        safety_notes.append("No current Production model found.")
+        return PromotionDecision(
+            candidate=candidate_summary,
+            current_production=None,
+            should_promote=True,
+            compare_status="no_current_production",
+            safety_notes=safety_notes,
+            risk_notes=risk_notes,
+        )
+
+    production_summary = _model_version_summary(current_production, client)
+    production_r2 = production_summary.metrics.get("test_r2")
+    production_rmse = production_summary.metrics.get("test_rmse")
+
+    if production_r2 is None or production_rmse is None:
+        risk_notes.append("Current Production metrics unavailable; manual metric comparison required.")
+        return PromotionDecision(
+            candidate=candidate_summary,
+            current_production=production_summary,
+            should_promote=False,
+            compare_status="current_production_metrics_unknown",
+            safety_notes=safety_notes,
+            risk_notes=risk_notes,
+        )
+
+    if candidate.test_r2 > production_r2:
+        safety_notes.append("Candidate improves Production test_r2.")
+        return PromotionDecision(
+            candidate=candidate_summary,
+            current_production=production_summary,
+            should_promote=True,
+            compare_status="candidate_improves_r2",
+            safety_notes=safety_notes,
+            risk_notes=risk_notes,
+        )
+
+    if candidate.test_r2 < production_r2:
+        risk_notes.append("Candidate test_r2 is lower than current Production.")
+        return PromotionDecision(
+            candidate=candidate_summary,
+            current_production=production_summary,
+            should_promote=False,
+            compare_status="candidate_degrades_r2",
+            safety_notes=safety_notes,
+            risk_notes=risk_notes,
+        )
+
+    if candidate.test_rmse <= production_rmse:
+        safety_notes.append("Candidate matches Production test_r2 and improves or matches test_rmse.")
+        return PromotionDecision(
+            candidate=candidate_summary,
+            current_production=production_summary,
+            should_promote=True,
+            compare_status="candidate_ties_r2_and_improves_rmse",
+            safety_notes=safety_notes,
+            risk_notes=risk_notes,
+        )
+
+    risk_notes.append("Candidate matches Production test_r2 but has higher test_rmse.")
+    return PromotionDecision(
+        candidate=candidate_summary,
+        current_production=production_summary,
+        should_promote=False,
+        compare_status="candidate_ties_r2_but_degrades_rmse",
+        safety_notes=safety_notes,
+        risk_notes=risk_notes,
+    )
+
+
+def _promotion_audit_tags(
+    decision: PromotionDecision,
+    *,
+    approval_mode: str,
+    approved: bool,
+) -> dict[str, str]:
+    tags = {
+        "promotion.decision_timestamp_utc": datetime.now(UTC).isoformat(),
+        "promotion.approved": str(approved).lower(),
+        "promotion.approval_mode": approval_mode,
+        "promotion.compare_status": decision.compare_status,
+        "promotion.should_promote": str(decision.should_promote).lower(),
+        "promotion.candidate.test_r2": str(decision.candidate.metrics["test_r2"]),
+        "promotion.candidate.test_rmse": str(decision.candidate.metrics["test_rmse"]),
+    }
+    if decision.current_production is not None:
+        tags["promotion.previous_production_version"] = decision.current_production.version
+        for metric_name, metric_value in decision.current_production.metrics.items():
+            tags[f"promotion.production.{metric_name}"] = str(metric_value)
+    else:
+        tags["promotion.previous_production_version"] = ""
+    return tags
+
+
+def _set_promotion_audit_tags(
+    client: Any,
+    model_name: str,
+    version: str,
+    decision: PromotionDecision,
+    *,
+    approval_mode: str,
+    approved: bool,
+) -> None:
+    for key, value in _promotion_audit_tags(
+        decision,
+        approval_mode=approval_mode,
+        approved=approved,
+    ).items():
+        client.set_model_version_tag(model_name, version, key, value)
+
+
+def promote_version_to_production(
+    client: Any,
+    model_name: str,
+    version: Any,
+    *,
+    decision: PromotionDecision,
+    approval_mode: str = "explicit_cli_yes",
+    approved: bool = True,
+) -> str:
+    if not decision.should_promote:
+        raise ValueError(f"Promotion rejected: {decision.compare_status}")
+    version_str = _version_str(version)
+    _set_promotion_audit_tags(
+        client,
+        model_name,
+        version_str,
+        decision,
+        approval_mode=approval_mode,
+        approved=approved,
+    )
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message=".*(transition_model_version_stage|model registry stages|deprecated).*",
+            category=FutureWarning,
+        )
+        warnings.filterwarnings(
+            "ignore",
+            message=".*(transition_model_version_stage|model registry stages|deprecated).*",
+            category=DeprecationWarning,
+        )
+        client.transition_model_version_stage(
+            name=model_name,
+            version=version_str,
+            stage="Staging",
+            archive_existing_versions=False,
+        )
+        client.transition_model_version_stage(
+            name=model_name,
+            version=version_str,
+            stage="Production",
+            archive_existing_versions=True,
+        )
+    return version_str
+
+
+def _verify_model_artifact_exists(
+    client: Any,
+    candidate: ModelRunCandidate,
+    artifact_path: str = "model",
+) -> None:
+    source = f"runs:/{candidate.run_id}/{artifact_path}"
+    try:
+        artifacts = client.list_artifacts(candidate.run_id, artifact_path)
+    except Exception as exc:
+        raise RuntimeError(f"Model artifact is not readable for run {candidate.run_id}: {source}") from exc
+
+    if not artifacts:
+        raise RuntimeError(f"Model artifact not found for run {candidate.run_id}: {source}")
+
+
+def prepare_candidate_registration(config_path: str | Path | None = None) -> RegistrationResult:
+    import mlflow
+    from mlflow.tracking import MlflowClient
+
+    from src.config import load_config
+
+    cfg = load_config(config_path) if config_path is not None else load_config()
+    tracking_uri = _resolve_tracking_uri(cfg.mlflow.tracking_uri)
+    mlflow.set_tracking_uri(tracking_uri)
+    client = MlflowClient(tracking_uri=tracking_uri)
+
+    candidate = find_best_model_run(
+        client,
+        cfg.mlflow.experiment_name,
+        min_test_r2=cfg.validation.min_test_r2,
+    )
+    existing_version = _find_existing_model_version_for_run(
+        client,
+        cfg.mlflow.registered_model_name,
+        candidate.run_id,
+    )
+    if existing_version is None:
+        _verify_model_artifact_exists(client, candidate)
+        version = register_candidate_model(client, candidate, cfg.mlflow.registered_model_name)
+        created = True
+    else:
+        version = existing_version
+        created = False
+
+    action = "created" if created else "reused"
+    print(
+        "registry: "
+        f"{action} "
+        f"model={cfg.mlflow.registered_model_name} "
+        f"version={version.version} "
+        f"run_id={candidate.run_id} "
+        f"test_r2={candidate.test_r2:.6f} "
+        f"test_rmse={candidate.test_rmse:.6f}"
+    )
+    return RegistrationResult(
+        candidate=candidate,
+        model_name=cfg.mlflow.registered_model_name,
+        version=version,
+        created=created,
+    )
+
+
+def evaluate_candidate_promotion(config_path: str | Path | None = None) -> PromotionDecision:
+    import mlflow
+    from mlflow.tracking import MlflowClient
+
+    from src.config import load_config
+
+    registration = prepare_candidate_registration(config_path)
+    cfg = load_config(config_path) if config_path is not None else load_config()
+    tracking_uri = _resolve_tracking_uri(cfg.mlflow.tracking_uri)
+    mlflow.set_tracking_uri(tracking_uri)
+    client = MlflowClient(tracking_uri=tracking_uri)
+
+    current_production = find_current_production_version(
+        client,
+        cfg.mlflow.registered_model_name,
+    )
+    decision = build_promotion_decision(
+        candidate=registration.candidate,
+        candidate_version=registration.version,
+        min_test_r2=cfg.validation.min_test_r2,
+        current_production=current_production,
+        client=client,
+    )
+    print(json.dumps(decision.to_dict(), indent=2, sort_keys=True))
+    return decision
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="MLflow registry utilities")
+    subparsers = parser.add_subparsers(dest="command")
+    prepare_parser = subparsers.add_parser("prepare", help="register the best eligible candidate")
+    prepare_parser.add_argument("--config", type=Path, default=None)
+    evaluate_parser = subparsers.add_parser(
+        "evaluate",
+        help="register/reuse the best eligible candidate and print a non-promoting decision",
+    )
+    evaluate_parser.add_argument("--config", type=Path, default=None)
+    promote_parser = subparsers.add_parser(
+        "promote",
+        help="explicitly promote the evaluated candidate to Production",
+    )
+    promote_parser.add_argument("--config", type=Path, default=None)
+    promote_parser.add_argument(
+        "--yes",
+        action="store_true",
+        help="confirm the human gate and execute the Production transition",
+    )
+
+    args = parser.parse_args(argv)
+    if args.command == "prepare":
+        prepare_candidate_registration(args.config)
+        return
+    if args.command == "evaluate":
+        evaluate_candidate_promotion(args.config)
+        return
+    if args.command == "promote":
+        if not args.yes:
+            decision = evaluate_candidate_promotion(args.config)
+            raise SystemExit(
+                "Promotion requires explicit human confirmation. "
+                "Review the decision above, then rerun with --yes."
+            )
+        import mlflow
+        from mlflow.tracking import MlflowClient
+
+        from src.config import load_config
+
+        decision = evaluate_candidate_promotion(args.config)
+        if not decision.should_promote:
+            raise SystemExit(f"Promotion rejected: {decision.compare_status}")
+        cfg = load_config(args.config) if args.config is not None else load_config()
+        tracking_uri = _resolve_tracking_uri(cfg.mlflow.tracking_uri)
+        mlflow.set_tracking_uri(tracking_uri)
+        client = MlflowClient(tracking_uri=tracking_uri)
+        version = promote_version_to_production(
+            client,
+            cfg.mlflow.registered_model_name,
+            decision.candidate.version,
+            decision=decision,
+        )
+        print(f"registry: promoted model={cfg.mlflow.registered_model_name} version={version}")
+        return
+    parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/training/train.py
+++ b/src/training/train.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Callable
+from pathlib import Path
+
+import joblib
+import pandas as pd
+from sklearn.ensemble import RandomForestRegressor
+
+from src.config import Config, load_config
+from src.evaluation.metrics import compute_metrics
+from src.features.preprocessor import build_preprocessor
+
+
+def _resolve_tracking_uri(configured_uri: str) -> str:
+    return os.environ.get("MLFLOW_TRACKING_URI") or configured_uri
+
+
+def _build_baseline_model(random_state: int) -> RandomForestRegressor:
+    return RandomForestRegressor(
+        n_estimators=100,
+        max_depth=8,
+        n_jobs=-1,
+        random_state=random_state,
+    )
+
+
+def _feature_columns(cfg: Config) -> list[str]:
+    return cfg.data.numeric_features + cfg.data.categorical_features
+
+
+def _build_model(params: dict, random_state: int) -> RandomForestRegressor:
+    return RandomForestRegressor(
+        **params,
+        n_jobs=-1,
+        random_state=random_state,
+    )
+
+
+def _validation_gate_info(test_metrics: dict[str, float], min_test_r2: float) -> dict:
+    return {
+        "min_test_r2": float(min_test_r2),
+        "passed": bool(test_metrics["r2"] >= min_test_r2),
+    }
+
+
+def _apply_validation_gate(test_metrics: dict[str, float], min_test_r2: float) -> dict:
+    gate = _validation_gate_info(test_metrics, min_test_r2)
+    if not gate["passed"]:
+        raise RuntimeError(
+            "Validation gate failed: "
+            f"test_r2={test_metrics['r2']:.6f} < min_test_r2={min_test_r2:.6f}"
+        )
+    return gate
+
+
+def _persist_artifacts_if_gate_passes(
+    test_metrics: dict[str, float],
+    min_test_r2: float,
+    persist_artifacts: Callable[[], None],
+) -> dict:
+    gate = _apply_validation_gate(test_metrics, min_test_r2)
+    persist_artifacts()
+    return gate
+
+
+def main() -> None:
+    import mlflow
+    import mlflow.sklearn
+
+    from src.training.hpo import run_hpo
+
+    cfg = load_config()
+    tracking_uri = _resolve_tracking_uri(cfg.mlflow.tracking_uri)
+
+    train = pd.read_parquet(cfg.paths.train)
+    test = pd.read_parquet(cfg.paths.test)
+    preprocessor = joblib.load(cfg.paths.preprocessor)
+
+    feature_columns = _feature_columns(cfg)
+    train_features = train[feature_columns]
+    test_features = test[feature_columns]
+    x_train = preprocessor.transform(train_features)
+    y_train = train[cfg.data.target]
+    x_test = preprocessor.transform(test_features)
+    y_test = test[cfg.data.target]
+
+    def preprocessor_factory():
+        return build_preprocessor(
+            numeric=cfg.data.numeric_features,
+            categorical=cfg.data.categorical_features,
+            k=cfg.preprocessing.feature_selection_k,
+            numeric_strategy=cfg.preprocessing.numeric_imputer_strategy,
+            categorical_strategy=cfg.preprocessing.categorical_imputer_strategy,
+        )
+
+    mlflow.set_tracking_uri(tracking_uri)
+    mlflow.set_experiment(cfg.mlflow.experiment_name)
+    with mlflow.start_run(run_name="parent_hpo"):
+        mlflow.log_params({
+            "model_type": cfg.training.model_type,
+            "cv_folds": cfg.training.cv_folds,
+            "n_trials": cfg.training.n_trials,
+            "feature_selection_k": cfg.preprocessing.feature_selection_k,
+            "validation_min_test_r2": cfg.validation.min_test_r2,
+        })
+        hpo_result = run_hpo(
+            train_features,
+            y_train,
+            search_space=cfg.training.hpo_search_space,
+            n_trials=cfg.training.n_trials,
+            cv_folds=cfg.training.cv_folds,
+            random_state=cfg.data.random_state,
+            preprocessor_factory=preprocessor_factory,
+        )
+        mlflow.log_params({f"best_{key}": value for key, value in hpo_result.best_params.items()})
+        mlflow.log_metric("best_cv_rmse", hpo_result.best_cv_rmse)
+
+        model = _build_model(hpo_result.best_params, random_state=cfg.data.random_state)
+        model.fit(x_train, y_train)
+        y_pred = model.predict(x_test)
+        test_metrics = compute_metrics(y_test, y_pred)
+        gate = _validation_gate_info(test_metrics, cfg.validation.min_test_r2)
+
+        metrics_payload = {
+            "test": test_metrics,
+            "best_params": hpo_result.best_params,
+            "best_cv_rmse": hpo_result.best_cv_rmse,
+            "gate": gate,
+        }
+
+        metrics_path = Path(cfg.paths.metrics)
+        metrics_path.parent.mkdir(parents=True, exist_ok=True)
+        metrics_path.write_text(
+            json.dumps(metrics_payload, indent=2, sort_keys=True),
+            encoding="utf-8",
+        )
+
+        mlflow.log_metrics({f"test_{key}": value for key, value in test_metrics.items()})
+        mlflow.log_metric("validation_min_test_r2", gate["min_test_r2"])
+        mlflow.log_param("validation_passed", gate["passed"])
+
+        def persist_artifacts() -> None:
+            model_path = Path(cfg.paths.model)
+            model_path.parent.mkdir(parents=True, exist_ok=True)
+            joblib.dump(model, model_path)
+            mlflow.sklearn.log_model(model, artifact_path="model")
+            mlflow.log_artifact(cfg.paths.preprocessor, artifact_path="preprocessor")
+
+        _persist_artifacts_if_gate_passes(
+            test_metrics,
+            cfg.validation.min_test_r2,
+            persist_artifacts,
+        )
+
+    print(
+        "train: "
+        f"tracking_uri={tracking_uri} "
+        f"best_cv_rmse={hpo_result.best_cv_rmse:.6f} "
+        f"test_r2={test_metrics['r2']:.6f} "
+        f"test_rmse={test_metrics['rmse']:.6f} "
+        f"gate={'passed' if gate['passed'] else 'failed'}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -7,3 +7,4 @@ def test_load_config_returns_expected_keys():
     assert cfg.training.n_trials > 0
     assert cfg.serving.api_port == 8000
     assert 0 < cfg.validation.min_test_r2 < 1
+    assert cfg.validation.rmse_threshold > 0

--- a/tests/unit/test_hpo.py
+++ b/tests/unit/test_hpo.py
@@ -1,0 +1,109 @@
+import numpy as np
+from sklearn.preprocessing import StandardScaler
+from src.training import hpo as hpo_module
+from src.training.hpo import run_hpo
+
+
+def test_run_hpo_uses_seeded_search_space_and_logs_trials(monkeypatch):
+    logged_params = []
+    logged_metrics = []
+    logged_step_metrics = []
+    run_kwargs = []
+    trial_params = []
+
+    class DummyRun:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+        def __enter__(self):
+            run_kwargs.append(self.kwargs)
+            return self
+
+        def __exit__(self, exc_type, exc_value, traceback):
+            return False
+
+    def fake_cross_val_score(estimator, X, y, cv, scoring, n_jobs):
+        params = estimator.get_params()
+        selected = {
+            "n_estimators": params["n_estimators"],
+            "max_depth": params["max_depth"],
+            "min_samples_leaf": params["min_samples_leaf"],
+            "random_state": params["random_state"],
+            "n_jobs": params["n_jobs"],
+        }
+        trial_params.append(selected)
+        rmse = 2.0
+        if selected["n_estimators"] == 20:
+            rmse -= 0.5
+        if selected["max_depth"] == 4:
+            rmse -= 0.25
+        return np.array([-(rmse**2), -(rmse**2)])
+
+    monkeypatch.setattr(hpo_module.mlflow, "start_run", lambda **kwargs: DummyRun(**kwargs))
+    monkeypatch.setattr(hpo_module.mlflow, "log_params", logged_params.append)
+    monkeypatch.setattr(hpo_module.mlflow, "log_metrics", logged_metrics.append)
+    monkeypatch.setattr(
+        hpo_module.mlflow,
+        "log_metric",
+        lambda key, value, step=None: logged_step_metrics.append(
+            {"key": key, "value": value, "step": step}
+        ),
+    )
+    monkeypatch.setattr(hpo_module, "cross_val_score", fake_cross_val_score)
+
+    search_space = {
+        "n_estimators": [10, 20],
+        "max_depth": [2, 4],
+        "min_samples_leaf": [1, 2],
+    }
+    X = np.arange(24).reshape(12, 2)
+    y = np.arange(12)
+
+    first = run_hpo(X, y, search_space, n_trials=4, cv_folds=2, random_state=123)
+    first_sequence = list(trial_params)
+    trial_params.clear()
+    second = run_hpo(X, y, search_space, n_trials=4, cv_folds=2, random_state=123)
+
+    assert first.best_params == second.best_params
+    assert first_sequence == trial_params
+    assert first.best_cv_rmse == second.best_cv_rmse
+    assert all(run["nested"] for run in run_kwargs)
+    assert all(params["random_state"] == 123 for params in logged_params)
+    assert [metric["step"] for metric in logged_step_metrics] == [0, 1, 2, 3, 0, 1, 2, 3]
+    assert all("cv_rmse" in metrics for metrics in logged_metrics)
+
+
+def test_run_hpo_uses_pipeline_with_preprocessor_when_factory_is_provided(monkeypatch):
+    estimators = []
+
+    class DummyRun:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc_value, traceback):
+            return False
+
+    def fake_cross_val_score(estimator, X, y, cv, scoring, n_jobs):
+        estimators.append(estimator)
+        return np.array([-1.0, -1.0])
+
+    monkeypatch.setattr(hpo_module.mlflow, "start_run", lambda **kwargs: DummyRun())
+    monkeypatch.setattr(hpo_module.mlflow, "log_params", lambda params: None)
+    monkeypatch.setattr(hpo_module.mlflow, "log_metrics", lambda metrics: None)
+    monkeypatch.setattr(hpo_module.mlflow, "log_metric", lambda key, value, step=None: None)
+    monkeypatch.setattr(hpo_module, "cross_val_score", fake_cross_val_score)
+
+    run_hpo(
+        np.arange(24).reshape(12, 2),
+        np.arange(12),
+        {"n_estimators": [10], "max_depth": [2], "min_samples_leaf": [1]},
+        n_trials=1,
+        cv_folds=2,
+        random_state=123,
+        preprocessor_factory=StandardScaler,
+    )
+
+    estimator = estimators[0]
+    assert [name for name, _ in estimator.steps] == ["preprocessor", "model"]
+    assert isinstance(estimator.named_steps["preprocessor"], StandardScaler)
+    assert estimator.named_steps["model"].random_state == 123

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -1,0 +1,17 @@
+import pytest
+from src.evaluation.metrics import compute_metrics
+
+
+def test_compute_metrics_returns_zero_errors_and_unit_r2_for_perfect_predictions():
+    metrics = compute_metrics([1.0, 2.0, 3.0], [1.0, 2.0, 3.0])
+
+    assert metrics["rmse"] == pytest.approx(0.0)
+    assert metrics["mae"] == pytest.approx(0.0)
+    assert metrics["r2"] == pytest.approx(1.0)
+
+
+def test_compute_metrics_returns_expected_keys():
+    metrics = compute_metrics([1.0, 2.0, 3.0], [1.0, 2.5, 2.0])
+
+    assert set(metrics) == {"rmse", "mae", "r2"}
+    assert all(isinstance(value, float) for value in metrics.values())

--- a/tests/unit/test_registry.py
+++ b/tests/unit/test_registry.py
@@ -1,0 +1,587 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import mlflow.tracking
+import pytest
+import src.config
+import src.training.registry as registry
+from src.training.registry import (
+    ModelRunCandidate,
+    _resolve_tracking_uri,
+    build_promotion_decision,
+    evaluate_candidate_promotion,
+    find_best_model_run,
+    prepare_candidate_registration,
+    promote_version_to_production,
+    register_candidate_model,
+    select_best_run,
+)
+
+
+def test_resolve_tracking_uri_prefers_environment_override(monkeypatch):
+    monkeypatch.setenv("MLFLOW_TRACKING_URI", "file:./mlruns")
+
+    assert _resolve_tracking_uri("http://localhost:5000") == "file:./mlruns"
+
+
+def test_select_best_run_filters_invalid_rows_and_orders_by_r2_then_rmse():
+    runs = [
+        {
+            "run_id": "missing-rmse",
+            "metrics.test_r2": 0.99,
+        },
+        {
+            "run_id": "low-r2",
+            "metrics.test_r2": 0.72,
+            "metrics.test_rmse": 50.0,
+            "params.model_type": "random_forest",
+        },
+        {
+            "run_id": "best-rmse",
+            "metrics.test_r2": 0.81,
+            "metrics.test_rmse": 60.0,
+        },
+        {
+            "run_id": "best-r2",
+            "metrics.test_r2": 0.82,
+            "metrics.test_rmse": 80.0,
+        },
+        {
+            "run_id": "invalid-r2",
+            "metrics.test_r2": "not-a-number",
+            "metrics.test_rmse": 1.0,
+        },
+    ]
+
+    selected = select_best_run(runs)
+
+    assert selected == ModelRunCandidate(
+        run_id="best-r2",
+        test_r2=0.82,
+        test_rmse=80.0,
+        metrics={"test_r2": 0.82, "test_rmse": 80.0},
+        params={},
+    )
+
+
+def test_select_best_run_uses_lowest_rmse_then_run_id_for_deterministic_ties():
+    runs = [
+        ModelRunCandidate(
+            run_id="run-c",
+            test_r2=0.8,
+            test_rmse=42.0,
+            metrics={"test_r2": 0.8, "test_rmse": 42.0},
+            params={},
+        ),
+        ModelRunCandidate(
+            run_id="run-a",
+            test_r2=0.8,
+            test_rmse=42.0,
+            metrics={"test_r2": 0.8, "test_rmse": 42.0},
+            params={},
+        ),
+        ModelRunCandidate(
+            run_id="run-b",
+            test_r2=0.8,
+            test_rmse=40.0,
+            metrics={"test_r2": 0.8, "test_rmse": 40.0},
+            params={},
+        ),
+    ]
+
+    assert select_best_run(runs).run_id == "run-b"
+    assert select_best_run(runs[:2]).run_id == "run-a"
+
+
+def test_select_best_run_excludes_gate_failed_candidates_when_validation_state_exists():
+    runs = [
+        {
+            "run_id": "gate-failed",
+            "metrics.test_r2": 0.95,
+            "metrics.test_rmse": 10.0,
+            "params.validation_passed": "False",
+        },
+        {
+            "run_id": "gate-passed",
+            "metrics.test_r2": 0.80,
+            "metrics.test_rmse": 20.0,
+            "tags.validation_passed": "true",
+        },
+    ]
+
+    assert select_best_run(runs).run_id == "gate-passed"
+
+
+def test_select_best_run_excludes_non_finished_candidates_when_status_exists():
+    runs = [
+        {
+            "run_id": "running",
+            "status": "RUNNING",
+            "metrics.test_r2": 0.95,
+            "metrics.test_rmse": 10.0,
+            "params.validation_passed": True,
+        },
+        {
+            "run_id": "finished",
+            "status": "FINISHED",
+            "metrics.test_r2": 0.80,
+            "metrics.test_rmse": 20.0,
+            "params.validation_passed": True,
+        },
+    ]
+
+    assert select_best_run(runs).run_id == "finished"
+
+
+def test_find_best_model_run_enforces_min_test_r2_gate():
+    class FakeClient:
+        def get_experiment_by_name(self, experiment_name):
+            assert experiment_name == "bike_sharing"
+            return SimpleNamespace(experiment_id="1")
+
+        def search_runs(self, experiment_ids, max_results):
+            assert experiment_ids == ["1"]
+            return [
+                SimpleNamespace(
+                    info=SimpleNamespace(run_id="below-gate", status="FINISHED"),
+                    data=SimpleNamespace(
+                        metrics={"test_r2": 0.69, "test_rmse": 66.7},
+                        params={"validation_passed": "True"},
+                        tags={},
+                    ),
+                )
+            ]
+
+    with pytest.raises(RuntimeError, match="No eligible model runs"):
+        find_best_model_run(FakeClient(), "bike_sharing", min_test_r2=0.70)
+
+
+def test_register_candidate_model_builds_runs_uri_and_sets_version_metadata():
+    calls = []
+
+    class FakeClient:
+        def create_registered_model(self, name):
+            calls.append(("create_registered_model", name))
+
+        def create_model_version(self, name, source, run_id):
+            calls.append(("create_model_version", name, source, run_id))
+            return SimpleNamespace(version="7")
+
+        def set_model_version_tag(self, name, version, key, value):
+            calls.append(("set_model_version_tag", name, version, key, value))
+
+    candidate = ModelRunCandidate(
+        run_id="abc123",
+        test_r2=0.757,
+        test_rmse=66.71,
+        metrics={"test_r2": 0.757, "test_rmse": 66.71, "best_cv_rmse": 64.39},
+        params={"model_type": "random_forest"},
+    )
+
+    version = register_candidate_model(FakeClient(), candidate, "bike_share_regressor")
+
+    assert version.version == "7"
+    assert ("create_model_version", "bike_share_regressor", "runs:/abc123/model", "abc123") in calls
+    assert (
+        "set_model_version_tag",
+        "bike_share_regressor",
+        "7",
+        "source_run_id",
+        "abc123",
+    ) in calls
+    assert (
+        "set_model_version_tag",
+        "bike_share_regressor",
+        "7",
+        "test_r2",
+        "0.757",
+    ) in calls
+    assert (
+        "set_model_version_tag",
+        "bike_share_regressor",
+        "7",
+        "test_rmse",
+        "66.71",
+    ) in calls
+    assert (
+        "set_model_version_tag",
+        "bike_share_regressor",
+        "7",
+        "param.model_type",
+        "random_forest",
+    ) in calls
+    assert (
+        "set_model_version_tag",
+        "bike_share_regressor",
+        "7",
+        "metric.best_cv_rmse",
+        "64.39",
+    ) in calls
+
+
+def test_find_best_model_run_keeps_search_page_size_within_mlflow_file_store_limit():
+    class FakeClient:
+        def get_experiment_by_name(self, experiment_name):
+            assert experiment_name == "bike_sharing"
+            return SimpleNamespace(experiment_id="1")
+
+        def search_runs(self, experiment_ids, max_results):
+            assert experiment_ids == ["1"]
+            assert max_results <= 50_000
+            return [
+                SimpleNamespace(
+                    info=SimpleNamespace(run_id="candidate"),
+                    data=SimpleNamespace(
+                        metrics={"test_r2": 0.75, "test_rmse": 66.7},
+                        params={},
+                    ),
+                )
+            ]
+
+    candidate = find_best_model_run(FakeClient(), "bike_sharing")
+
+    assert candidate.run_id == "candidate"
+
+
+def _registry_config(min_test_r2=0.70, rmse_threshold=80.0):
+    return SimpleNamespace(
+        mlflow=SimpleNamespace(
+            tracking_uri="http://localhost:5000",
+            experiment_name="bike_sharing",
+            registered_model_name="bike_share_regressor",
+        ),
+        validation=SimpleNamespace(min_test_r2=min_test_r2, rmse_threshold=rmse_threshold),
+    )
+
+
+def _finished_candidate_run(run_id="candidate", test_r2=0.80):
+    return SimpleNamespace(
+        info=SimpleNamespace(run_id=run_id, status="FINISHED"),
+        data=SimpleNamespace(
+            metrics={"test_r2": test_r2, "test_rmse": 66.7},
+            params={"validation_passed": "True"},
+            tags={},
+        ),
+    )
+
+
+def test_prepare_candidate_registration_reuses_existing_version_without_promotion(monkeypatch):
+    calls = []
+
+    class FakeClient:
+        def get_experiment_by_name(self, experiment_name):
+            return SimpleNamespace(experiment_id="1")
+
+        def search_runs(self, experiment_ids, max_results):
+            return [_finished_candidate_run(run_id="existing-run")]
+
+        def search_model_versions(self, filter_string):
+            calls.append(("search_model_versions", filter_string))
+            return [
+                SimpleNamespace(
+                    version="3",
+                    run_id="existing-run",
+                    source="runs:/existing-run/model",
+                    tags={"run_id": "existing-run"},
+                )
+            ]
+
+        def create_model_version(self, name, source, run_id):
+            raise AssertionError("prepare should reuse existing version")
+
+        def transition_model_version_stage(self, *args, **kwargs):
+            raise AssertionError("prepare must not promote stages")
+
+        def set_registered_model_alias(self, *args, **kwargs):
+            raise AssertionError("prepare must not set aliases")
+
+    fake_client = FakeClient()
+    monkeypatch.setattr(src.config, "load_config", lambda: _registry_config())
+    monkeypatch.setattr(mlflow.tracking, "MlflowClient", lambda tracking_uri: fake_client)
+
+    result = prepare_candidate_registration()
+
+    assert result.created is False
+    assert result.version.version == "3"
+    assert calls == [("search_model_versions", "name = 'bike_share_regressor'")]
+
+
+def test_prepare_candidate_registration_checks_model_artifact_before_registering(monkeypatch):
+    class FakeClient:
+        def get_experiment_by_name(self, experiment_name):
+            return SimpleNamespace(experiment_id="1")
+
+        def search_runs(self, experiment_ids, max_results):
+            return [_finished_candidate_run(run_id="missing-artifact")]
+
+        def search_model_versions(self, filter_string):
+            return []
+
+        def list_artifacts(self, run_id, path):
+            assert (run_id, path) == ("missing-artifact", "model")
+            return []
+
+        def create_model_version(self, name, source, run_id):
+            raise AssertionError("missing artifact should block registration")
+
+    fake_client = FakeClient()
+    monkeypatch.setattr(src.config, "load_config", lambda: _registry_config())
+    monkeypatch.setattr(mlflow.tracking, "MlflowClient", lambda tracking_uri: fake_client)
+
+    with pytest.raises(RuntimeError, match="Model artifact"):
+        prepare_candidate_registration()
+
+
+def _candidate(run_id="candidate", test_r2=0.80, test_rmse=66.7):
+    return ModelRunCandidate(
+        run_id=run_id,
+        test_r2=test_r2,
+        test_rmse=test_rmse,
+        metrics={"test_r2": test_r2, "test_rmse": test_rmse},
+        params={},
+    )
+
+
+def _version(version="7", run_id="candidate", stage="None", tags=None):
+    return SimpleNamespace(
+        version=version,
+        run_id=run_id,
+        current_stage=stage,
+        tags=tags or {},
+    )
+
+
+def test_promotion_decision_allows_candidate_without_current_production_when_gate_passes():
+    decision = build_promotion_decision(
+        candidate=_candidate(test_r2=0.81, test_rmse=61.0),
+        candidate_version=_version(version="5"),
+        min_test_r2=0.70,
+        current_production=None,
+    )
+
+    assert decision.should_promote is True
+    assert decision.candidate.run_id == "candidate"
+    assert decision.candidate.version == "5"
+    assert decision.current_production is None
+    assert decision.compare_status == "no_current_production"
+    assert "No current Production model found." in decision.safety_notes
+
+
+def test_promotion_decision_rejects_candidate_below_minimum_gate():
+    decision = build_promotion_decision(
+        candidate=_candidate(test_r2=0.69, test_rmse=61.0),
+        candidate_version=_version(version="5"),
+        min_test_r2=0.70,
+        current_production=None,
+    )
+
+    assert decision.should_promote is False
+    assert decision.compare_status == "below_min_test_r2"
+    assert "Candidate test_r2=0.690000 is below promotion gate 0.700000." in decision.risk_notes
+
+
+def test_promotion_decision_rejects_degradation_vs_current_production():
+    decision = build_promotion_decision(
+        candidate=_candidate(test_r2=0.80, test_rmse=61.0),
+        candidate_version=_version(version="5"),
+        min_test_r2=0.70,
+        current_production=_version(
+            version="4",
+            run_id="prod-run",
+            stage="Production",
+            tags={"test_r2": "0.82", "test_rmse": "64.0"},
+        ),
+    )
+
+    assert decision.should_promote is False
+    assert decision.compare_status == "candidate_degrades_r2"
+    assert decision.current_production.version == "4"
+    assert decision.current_production.metrics == {"test_r2": 0.82, "test_rmse": 64.0}
+
+
+def test_promotion_decision_allows_equal_r2_with_lower_rmse_tie_break():
+    decision = build_promotion_decision(
+        candidate=_candidate(test_r2=0.82, test_rmse=60.0),
+        candidate_version=_version(version="5"),
+        min_test_r2=0.70,
+        current_production=_version(
+            version="4",
+            run_id="prod-run",
+            stage="Production",
+            tags={"test_r2": "0.82", "test_rmse": "64.0"},
+        ),
+    )
+
+    assert decision.should_promote is True
+    assert decision.compare_status == "candidate_ties_r2_and_improves_rmse"
+    assert "Candidate matches Production test_r2 and improves or matches test_rmse." in decision.safety_notes
+
+
+def test_promotion_decision_rejects_equal_r2_with_higher_rmse_tie_break():
+    decision = build_promotion_decision(
+        candidate=_candidate(test_r2=0.82, test_rmse=70.0),
+        candidate_version=_version(version="5"),
+        min_test_r2=0.70,
+        current_production=_version(
+            version="4",
+            run_id="prod-run",
+            stage="Production",
+            tags={"test_r2": "0.82", "test_rmse": "64.0"},
+        ),
+    )
+
+    assert decision.should_promote is False
+    assert decision.compare_status == "candidate_ties_r2_but_degrades_rmse"
+    assert "Candidate matches Production test_r2 but has higher test_rmse." in decision.risk_notes
+
+
+def test_promotion_decision_rejects_when_current_production_metrics_unknown():
+    decision = build_promotion_decision(
+        candidate=_candidate(test_r2=0.82, test_rmse=60.0),
+        candidate_version=_version(version="5"),
+        min_test_r2=0.70,
+        current_production=_version(version="4", run_id="prod-run", stage="Production"),
+    )
+
+    assert decision.should_promote is False
+    assert decision.compare_status == "current_production_metrics_unknown"
+    assert decision.current_production.metrics == {}
+    assert "Current Production metrics unavailable; manual metric comparison required." in decision.risk_notes
+
+
+def test_promotion_decision_resolves_current_production_metrics_from_run_when_tags_missing():
+    class FakeClient:
+        def get_run(self, run_id):
+            assert run_id == "prod-run"
+            return SimpleNamespace(
+                data=SimpleNamespace(metrics={"test_r2": 0.81, "test_rmse": 64.0})
+            )
+
+    decision = build_promotion_decision(
+        candidate=_candidate(test_r2=0.82, test_rmse=60.0),
+        candidate_version=_version(version="5"),
+        min_test_r2=0.70,
+        current_production=_version(version="4", run_id="prod-run", stage="Production"),
+        client=FakeClient(),
+    )
+
+    assert decision.should_promote is True
+    assert decision.compare_status == "candidate_improves_r2"
+    assert decision.current_production.metrics == {"test_r2": 0.81, "test_rmse": 64.0}
+
+
+def test_main_default_path_prints_help_without_registration_or_promotion(monkeypatch, capsys):
+    def fail_if_called(*args, **kwargs):
+        raise AssertionError("default CLI path must not prepare, evaluate, or promote")
+
+    monkeypatch.setattr(registry, "prepare_candidate_registration", fail_if_called)
+    monkeypatch.setattr(registry, "evaluate_candidate_promotion", fail_if_called)
+    monkeypatch.setattr(registry, "promote_version_to_production", fail_if_called)
+
+    registry.main([])
+
+    captured = capsys.readouterr()
+    assert "usage:" in captured.out
+    assert "prepare" in captured.out
+    assert "evaluate" in captured.out
+    assert "promote" in captured.out
+    assert captured.err == ""
+
+
+def test_promote_version_to_production_transitions_staging_then_production_and_archives():
+    calls = []
+
+    class FakeClient:
+        def transition_model_version_stage(self, **kwargs):
+            calls.append(kwargs)
+
+        def set_model_version_tag(self, name, version, key, value):
+            calls.append(
+                {
+                    "name": name,
+                    "version": version,
+                    "key": key,
+                    "value": value,
+                }
+            )
+
+    decision = build_promotion_decision(
+        candidate=_candidate(test_r2=0.82, test_rmse=60.0),
+        candidate_version=_version(version="7"),
+        min_test_r2=0.70,
+        current_production=_version(
+            version="4",
+            run_id="prod-run",
+            stage="Production",
+            tags={"test_r2": "0.81", "test_rmse": "64.0"},
+        ),
+    )
+
+    promote_version_to_production(
+        FakeClient(),
+        "bike_share_regressor",
+        "7",
+        decision=decision,
+        approval_mode="test",
+    )
+
+    transition_calls = [call for call in calls if "stage" in call]
+    tag_calls = [call for call in calls if "key" in call]
+    assert transition_calls == [
+        {
+            "name": "bike_share_regressor",
+            "version": "7",
+            "stage": "Staging",
+            "archive_existing_versions": False,
+        },
+        {
+            "name": "bike_share_regressor",
+            "version": "7",
+            "stage": "Production",
+            "archive_existing_versions": True,
+        },
+    ]
+    tags = {call["key"]: call["value"] for call in tag_calls}
+    assert tags["promotion.approved"] == "true"
+    assert tags["promotion.approval_mode"] == "test"
+    assert tags["promotion.previous_production_version"] == "4"
+    assert tags["promotion.compare_status"] == "candidate_improves_r2"
+    assert tags["promotion.candidate.test_r2"] == "0.82"
+    assert tags["promotion.candidate.test_rmse"] == "60.0"
+    assert tags["promotion.production.test_r2"] == "0.81"
+    assert tags["promotion.production.test_rmse"] == "64.0"
+    assert "promotion.decision_timestamp_utc" in tags
+
+
+def test_evaluate_candidate_promotion_prepares_and_decides_without_stage_transition(monkeypatch):
+    class FakeClient:
+        def get_experiment_by_name(self, experiment_name):
+            return SimpleNamespace(experiment_id="1")
+
+        def search_runs(self, experiment_ids, max_results):
+            return [_finished_candidate_run(run_id="existing-run")]
+
+        def search_model_versions(self, filter_string):
+            return [
+                SimpleNamespace(
+                    version="3",
+                    run_id="existing-run",
+                    source="runs:/existing-run/model",
+                    current_stage="None",
+                    tags={"run_id": "existing-run", "test_r2": "0.80", "test_rmse": "66.7"},
+                )
+            ]
+
+        def transition_model_version_stage(self, *args, **kwargs):
+            raise AssertionError("evaluate must not promote stages")
+
+    fake_client = FakeClient()
+    monkeypatch.setattr(src.config, "load_config", lambda: _registry_config())
+    monkeypatch.setattr(mlflow.tracking, "MlflowClient", lambda tracking_uri: fake_client)
+
+    decision = evaluate_candidate_promotion()
+
+    assert decision.should_promote is True
+    assert decision.candidate.version == "3"
+    assert decision.current_production is None

--- a/tests/unit/test_scripts.py
+++ b/tests/unit/test_scripts.py
@@ -1,0 +1,96 @@
+import pandas as pd
+import pytest
+import scripts.export_runs as export_runs_module
+from scripts.compute_subgroup_metrics import build_subgroup_payload
+from scripts.export_runs import export_runs, write_experiment_log
+
+
+def test_build_subgroup_payload_includes_overall_and_filters_small_groups():
+    df = pd.DataFrame({
+        "season": [1] * 35 + [2] * 25,
+        "weathersit": [1] * 60,
+        "workingday": [0] * 30 + [1] * 30,
+    })
+    y_true = [10.0] * 60
+    y_pred = [12.0] * 35 + [8.0] * 25
+
+    payload = build_subgroup_payload(
+        df,
+        y_true,
+        y_pred,
+        group_fields=["season"],
+        min_n=30,
+    )
+
+    assert set(payload) == {"overall", "subgroups"}
+    assert set(payload["overall"]) == {"rmse", "mae", "r2"}
+    assert list(payload["subgroups"]) == ["season"]
+    assert len(payload["subgroups"]["season"]) == 1
+    season_group = payload["subgroups"]["season"][0]
+    assert season_group["value"] == 1
+    assert season_group["n"] == 35
+    assert set(season_group) == {"value", "n", "rmse", "mae", "r2"}
+
+
+def test_write_experiment_log_writes_dataframe_to_csv(tmp_path):
+    runs = pd.DataFrame({
+        "run_id": ["abc"],
+        "metrics.test_r2": [0.75],
+        "params.model_type": ["random_forest"],
+    })
+    output_path = tmp_path / "experiment_log.csv"
+
+    row_count = write_experiment_log(runs, output_path)
+
+    assert row_count == 1
+    written = pd.read_csv(output_path)
+    assert written.to_dict(orient="records") == runs.to_dict(orient="records")
+
+
+def test_write_experiment_log_rejects_empty_dataframe(tmp_path):
+    with pytest.raises(ValueError, match="No runs"):
+        write_experiment_log(pd.DataFrame(), tmp_path / "experiment_log.csv")
+
+
+def test_export_runs_is_read_only_and_uses_mlflow_api(monkeypatch, tmp_path):
+    class _MlflowCfg:
+        tracking_uri = "file:./mlruns"
+        experiment_name = "bike_sharing"
+
+    class _Cfg:
+        mlflow = _MlflowCfg()
+
+    class _Experiment:
+        experiment_id = "1"
+
+    def fail_if_repair_called(*_args, **_kwargs):
+        raise AssertionError("export should not mutate MLflow metadata")
+
+    runs = pd.DataFrame({"run_id": ["abc"], "metrics.test_r2": [0.75]})
+    output_path = tmp_path / "experiment_log.csv"
+
+    monkeypatch.setattr(export_runs_module, "load_config", lambda: _Cfg())
+    monkeypatch.setattr(
+        export_runs_module,
+        "ensure_run_uuid_compatibility",
+        fail_if_repair_called,
+        raising=False,
+    )
+    monkeypatch.setattr(export_runs_module.mlflow, "set_tracking_uri", lambda _uri: None)
+    monkeypatch.setattr(
+        export_runs_module.mlflow,
+        "get_experiment_by_name",
+        lambda _name: _Experiment(),
+    )
+    monkeypatch.setattr(
+        export_runs_module.mlflow,
+        "search_runs",
+        lambda experiment_ids, output_format: runs,
+    )
+
+    row_count = export_runs(output_path)
+
+    assert row_count == 1
+    assert pd.read_csv(output_path).to_dict(orient="records") == runs.to_dict(
+        orient="records"
+    )

--- a/tests/unit/test_train.py
+++ b/tests/unit/test_train.py
@@ -1,0 +1,71 @@
+from types import SimpleNamespace
+
+import pytest
+from src.training.train import (
+    _apply_validation_gate,
+    _build_baseline_model,
+    _feature_columns,
+    _persist_artifacts_if_gate_passes,
+    _resolve_tracking_uri,
+)
+
+
+def test_resolve_tracking_uri_prefers_environment_override(monkeypatch):
+    monkeypatch.setenv("MLFLOW_TRACKING_URI", "file:./mlruns")
+
+    assert _resolve_tracking_uri("http://localhost:5000") == "file:./mlruns"
+
+
+def test_resolve_tracking_uri_uses_config_value_when_env_missing(monkeypatch):
+    monkeypatch.delenv("MLFLOW_TRACKING_URI", raising=False)
+
+    assert _resolve_tracking_uri("http://localhost:5000") == "http://localhost:5000"
+
+
+def test_build_baseline_model_uses_required_deterministic_parameters():
+    model = _build_baseline_model(random_state=42)
+    params = model.get_params()
+
+    assert params["n_estimators"] == 100
+    assert params["max_depth"] == 8
+    assert params["n_jobs"] == -1
+    assert params["random_state"] == 42
+
+
+def test_feature_columns_returns_numeric_then_categorical_columns():
+    cfg = SimpleNamespace(
+        data=SimpleNamespace(
+            numeric_features=["temp", "atemp", "hum"],
+            categorical_features=["season", "holiday"],
+        )
+    )
+
+    assert _feature_columns(cfg) == ["temp", "atemp", "hum", "season", "holiday"]
+
+
+def test_apply_validation_gate_passes_when_r2_meets_threshold():
+    gate = _apply_validation_gate({"r2": 0.70}, min_test_r2=0.70)
+
+    assert gate == {"min_test_r2": 0.70, "passed": True}
+
+
+def test_apply_validation_gate_raises_when_r2_is_below_threshold():
+    with pytest.raises(RuntimeError, match="Validation gate failed"):
+        _apply_validation_gate({"r2": 0.69}, min_test_r2=0.70)
+
+
+def test_persist_artifacts_if_gate_passes_raises_before_artifact_persistence():
+    artifact_persisted = False
+
+    def persist_artifacts():
+        nonlocal artifact_persisted
+        artifact_persisted = True
+
+    with pytest.raises(RuntimeError, match="Validation gate failed"):
+        _persist_artifacts_if_gate_passes(
+            {"r2": 0.69},
+            min_test_r2=0.70,
+            persist_artifacts=persist_artifacts,
+        )
+
+    assert artifact_persisted is False


### PR DESCRIPTION
## Summary
- Sklearn preprocessing path is integrated with DVC (preprocess → featurize → **train**).
- Optuna HPO, MLflow experiment logging, and registry utilities; validation gate on test metrics.
- Committed `data/splits/metrics.json` (with `.gitignore` exception) for downstream CI gates.
- Unit tests for training, HPO, metrics, registry, and export scripts.

## Closes
Closes #3 
## Checklist
- [ ] CI green on this PR (after merge, add required checks: `lint`, `test`, `data-validation`, `model-validation` on `main` if the workflow is only on the other branch for now)
- [ ] At least one approval before merge (squash merge per team policy)