### PR TITLE
feat: Component 4+5 — FastAPI serving and GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,125 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Ruff
+        run: ruff check src/ tests/
+
+  test:
+    name: test
+    needs: [lint]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Pytest with coverage
+        run: |
+          pytest tests/ --cov=src --cov-report=term-missing --cov-report=xml --cov-fail-under=70
+
+      - name: Upload coverage XML
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-xml
+          path: coverage.xml
+
+  data-validation:
+    name: data-validation
+    needs: [test]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Data validation (Pandera)
+        run: python -m pytest tests/data/ -v
+
+  model-validation:
+    name: model-validation
+    needs: [data-validation]
+    runs-on: ubuntu-latest
+    env:
+      PYTHONPATH: ${{ github.workspace }}
+      SKIP_MLFLOW_REGISTRY: "1"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Model validation
+        run: python scripts/validate_model.py

--- a/scripts/validate_model.py
+++ b/scripts/validate_model.py
@@ -1,0 +1,56 @@
+"""Gate CI on committed test metrics and (optionally) the MLflow Production model."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import mlflow
+import mlflow.sklearn
+
+from src.config import load_config
+
+
+def _load_rmse(metrics_path: Path) -> float:
+    payload = json.loads(metrics_path.read_text(encoding="utf-8"))
+    return float(payload["test"]["rmse"])
+
+
+def main() -> int:
+    cfg = load_config()
+    metrics_path = Path(cfg.paths.metrics)
+    if not metrics_path.is_file():
+        print(f"ERROR: metrics file not found: {metrics_path}", file=sys.stderr)
+        return 1
+
+    rmse = _load_rmse(metrics_path)
+    ceiling = cfg.validation.rmse_threshold
+    if rmse >= ceiling:
+        print(
+            f"ERROR: test RMSE {rmse:.6f} >= validation.rmse_threshold {ceiling:.6f}",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"OK: test RMSE {rmse:.6f} < rmse_threshold {ceiling:.6f}")
+
+    if os.environ.get("SKIP_MLFLOW_REGISTRY", "").lower() in {"1", "true", "yes"}:
+        print("SKIP_MLFLOW_REGISTRY set: skipping Production model load")
+        return 0
+
+    tracking = os.environ.get("MLFLOW_TRACKING_URI", cfg.mlflow.tracking_uri)
+    mlflow.set_tracking_uri(tracking)
+    name = cfg.mlflow.registered_model_name
+    uri = f"models:/{name}/Production"
+    try:
+        mlflow.sklearn.load_model(uri)
+    except Exception as exc:
+        print(f"ERROR: could not load registry model {uri}: {exc}", file=sys.stderr)
+        return 1
+    print(f"OK: loaded registry model {uri}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/serving/app.py
+++ b/src/serving/app.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import os
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from typing import Any
+
+import joblib
+import mlflow
+import mlflow.sklearn
+import numpy as np
+import pandas as pd
+from fastapi import FastAPI, HTTPException, Response
+from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
+
+from src.config import Config, load_config
+from src.serving.metrics import (
+    FEATURE_HR,
+    FEATURE_TEMP,
+    INFERENCE_COUNT,
+    MODEL_VERSION,
+    PREDICTION_CONFIDENCE,
+    PREDICTION_VALUE,
+)
+from src.serving.schemas import (
+    BatchPredictionItem,
+    BatchPredictRequest,
+    BatchPredictResponse,
+    BikeRecord,
+    HealthResponse,
+    PredictResponse,
+)
+
+
+@dataclass
+class LoadedModel:
+    model: Any
+    preprocessor: Any
+    model_name: str
+    model_version: str
+
+
+def _resolve_tracking_uri(cfg: Config) -> str:
+    return os.environ.get("MLFLOW_TRACKING_URI") or cfg.mlflow.tracking_uri
+
+
+def _feature_columns(cfg: Config) -> list[str]:
+    return cfg.data.numeric_features + cfg.data.categorical_features
+
+
+def _load_model(cfg: Config) -> tuple[Any, str]:
+    model_name = cfg.mlflow.registered_model_name
+    model_uri = f"models:/{model_name}/Production"
+    mlflow.set_tracking_uri(_resolve_tracking_uri(cfg))
+    try:
+        return mlflow.sklearn.load_model(model_uri), "Production"
+    except Exception:
+        return joblib.load(cfg.paths.model), "local"
+
+
+def load_artifacts() -> LoadedModel:
+    cfg = load_config()
+    model, model_version = _load_model(cfg)
+    preprocessor = joblib.load(cfg.paths.preprocessor)
+    return LoadedModel(
+        model=model,
+        preprocessor=preprocessor,
+        model_name=cfg.mlflow.registered_model_name,
+        model_version=model_version,
+    )
+
+
+def _to_dataframe(records: list[BikeRecord]) -> pd.DataFrame:
+    cfg = load_config()
+    return pd.DataFrame([record.model_dump() for record in records])[_feature_columns(cfg)]
+
+
+def _predict_with_confidence(model: Any, features: np.ndarray) -> list[BatchPredictionItem]:
+    predictions = np.asarray(model.predict(features), dtype=float)
+    if hasattr(model, "estimators_"):
+        tree_predictions = np.asarray([tree.predict(features) for tree in model.estimators_])
+        std = tree_predictions.std(axis=0)
+        confidence = 1.0 / (1.0 + (std / (np.abs(predictions) + 1e-9)))
+    else:
+        confidence = np.ones_like(predictions, dtype=float)
+
+    return [
+        BatchPredictionItem(
+            prediction=float(prediction),
+            confidence=float(np.clip(score, 0.0, 1.0)),
+        )
+        for prediction, score in zip(predictions, confidence, strict=True)
+    ]
+
+
+def _loaded_model(app: FastAPI) -> LoadedModel:
+    loaded = getattr(app.state, "loaded_model", None)
+    if loaded is None:
+        raise HTTPException(status_code=503, detail="model is not loaded")
+    return loaded
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    loaded = load_artifacts()
+    app.state.loaded_model = loaded
+    MODEL_VERSION.labels(version=loaded.model_version).set(1)
+    yield
+
+
+app = FastAPI(title="Bike Sharing Predictor", lifespan=lifespan)
+
+
+@app.get("/health", response_model=HealthResponse)
+def health() -> HealthResponse:
+    loaded = _loaded_model(app)
+    return HealthResponse(
+        status="ok",
+        model_name=loaded.model_name,
+        model_version=loaded.model_version,
+    )
+
+
+@app.post("/predict", response_model=PredictResponse)
+def predict(record: BikeRecord) -> PredictResponse:
+    loaded = _loaded_model(app)
+    df = _to_dataframe([record])
+    features = loaded.preprocessor.transform(df)
+    item = _predict_with_confidence(loaded.model, features)[0]
+    FEATURE_TEMP.observe(record.temp)
+    FEATURE_HR.observe(record.hr)
+    PREDICTION_CONFIDENCE.observe(item.confidence)
+    PREDICTION_VALUE.observe(item.prediction)
+    INFERENCE_COUNT.labels(endpoint="/predict").inc()
+    return PredictResponse(
+        prediction=item.prediction,
+        confidence=item.confidence,
+        model_version=loaded.model_version,
+    )
+
+
+@app.post("/predict/batch", response_model=BatchPredictResponse)
+def predict_batch(request: BatchPredictRequest) -> BatchPredictResponse:
+    loaded = _loaded_model(app)
+    df = _to_dataframe(request.records)
+    features = loaded.preprocessor.transform(df)
+    items = _predict_with_confidence(loaded.model, features)
+    for record, item in zip(request.records, items, strict=True):
+        FEATURE_TEMP.observe(record.temp)
+        FEATURE_HR.observe(record.hr)
+        PREDICTION_CONFIDENCE.observe(item.confidence)
+        PREDICTION_VALUE.observe(item.prediction)
+    INFERENCE_COUNT.labels(endpoint="/predict/batch").inc()
+    return BatchPredictResponse(predictions=items, model_version=loaded.model_version)
+
+
+@app.get("/metrics")
+def metrics() -> Response:
+    return Response(generate_latest(), media_type=CONTENT_TYPE_LATEST)

--- a/src/serving/metrics.py
+++ b/src/serving/metrics.py
@@ -1,0 +1,32 @@
+from prometheus_client import Counter, Gauge, Histogram
+
+PREDICTION_CONFIDENCE = Histogram(
+    "bike_prediction_confidence",
+    "Histogram of per-prediction confidence scores in [0,1]",
+    buckets=(0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0),
+)
+FEATURE_TEMP = Histogram(
+    "bike_feature_temp",
+    "Histogram of normalized temperature input feature",
+    buckets=(0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0),
+)
+FEATURE_HR = Histogram(
+    "bike_feature_hr",
+    "Histogram of hour-of-day input feature",
+    buckets=tuple(range(0, 25, 3)),
+)
+MODEL_VERSION = Gauge(
+    "bike_model_version_info",
+    "Currently loaded model version label",
+    ["version"],
+)
+INFERENCE_COUNT = Counter(
+    "bike_inference_total",
+    "Total number of inference requests by endpoint",
+    ["endpoint"],
+)
+PREDICTION_VALUE = Histogram(
+    "bike_prediction_value",
+    "Histogram of predicted rental counts",
+    buckets=(0, 25, 50, 100, 200, 400, 800, 1600),
+)

--- a/src/serving/schemas.py
+++ b/src/serving/schemas.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class BikeRecord(BaseModel):
+    season: int = Field(..., ge=1, le=4)
+    mnth: int = Field(..., ge=1, le=12)
+    hr: int = Field(..., ge=0, le=23)
+    holiday: int = Field(..., ge=0, le=1)
+    weekday: int = Field(..., ge=0, le=6)
+    workingday: int = Field(..., ge=0, le=1)
+    weathersit: int = Field(..., ge=1, le=4)
+    temp: float = Field(..., ge=0.0, le=1.0)
+    atemp: float = Field(..., ge=0.0, le=1.0)
+    hum: float = Field(..., ge=0.0, le=1.0)
+    windspeed: float = Field(..., ge=0.0, le=1.0)
+
+
+class PredictResponse(BaseModel):
+    prediction: float
+    confidence: float = Field(..., ge=0.0, le=1.0)
+    model_version: str
+
+
+class BatchPredictionItem(BaseModel):
+    prediction: float
+    confidence: float = Field(..., ge=0.0, le=1.0)
+
+
+class BatchPredictRequest(BaseModel):
+    records: list[BikeRecord] = Field(..., min_length=1)
+
+
+class BatchPredictResponse(BaseModel):
+    predictions: list[BatchPredictionItem]
+    model_version: str
+
+
+class HealthResponse(BaseModel):
+    status: str
+    model_name: str
+    model_version: str

--- a/tests/data/sample_hour.csv
+++ b/tests/data/sample_hour.csv
@@ -1,0 +1,4 @@
+instant,dteday,season,yr,mnth,hr,holiday,weekday,workingday,weathersit,temp,atemp,hum,windspeed,casual,registered,cnt
+1,2011-01-01,1,0,1,0,0,6,0,1,0.24,0.288,0.81,0.0,3,13,16
+2,2011-01-01,1,0,1,1,0,6,0,1,0.22,0.27,0.80,0.05,4,15,19
+3,2011-01-02,1,0,1,2,0,0,1,1,0.20,0.25,0.79,0.10,5,20,25

--- a/tests/data/test_data_validation.py
+++ b/tests/data/test_data_validation.py
@@ -1,4 +1,6 @@
-﻿import pandas as pd
+﻿from pathlib import Path
+
+import pandas as pd
 import pytest
 from src.data.schema import raw_schema
 
@@ -31,3 +33,9 @@ def test_schema_rejects_zero_or_negative_count():
     df = pd.DataFrame([bad])
     with pytest.raises(Exception):
         raw_schema.validate(df)
+
+
+def test_sample_hour_csv_passes_schema():
+    csv_path = Path(__file__).resolve().parent / "sample_hour.csv"
+    df = pd.read_csv(csv_path)
+    raw_schema.validate(df)

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -1,0 +1,41 @@
+from fastapi.testclient import TestClient
+from src.serving.app import app
+
+VALID_RECORD = {
+    "season": 2,
+    "mnth": 6,
+    "hr": 12,
+    "holiday": 0,
+    "weekday": 3,
+    "workingday": 1,
+    "weathersit": 1,
+    "temp": 0.62,
+    "atemp": 0.60,
+    "hum": 0.45,
+    "windspeed": 0.20,
+}
+
+
+def test_health_predict_batch_and_metrics():
+    with TestClient(app) as client:
+        health = client.get("/health")
+        assert health.status_code == 200
+        assert health.json()["model_name"] == "bike_share_regressor"
+        assert health.json()["model_version"]
+
+        prediction = client.post("/predict", json=VALID_RECORD)
+        assert prediction.status_code == 200
+        prediction_body = prediction.json()
+        assert isinstance(prediction_body["prediction"], float)
+        assert 0.0 <= prediction_body["confidence"] <= 1.0
+        assert prediction_body["model_version"] == health.json()["model_version"]
+
+        batch = client.post("/predict/batch", json={"records": [VALID_RECORD, VALID_RECORD]})
+        assert batch.status_code == 200
+        batch_body = batch.json()
+        assert len(batch_body["predictions"]) == 2
+        assert all("prediction" in item and "confidence" in item for item in batch_body["predictions"])
+
+        metrics = client.get("/metrics")
+        assert metrics.status_code == 200
+        assert "bike_inference_total" in metrics.text

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -1,5 +1,15 @@
+"""API integration tests.
+
+GitHub Actions does not ship ``data/splits/model.pkl`` or a local MLflow server, so we patch
+``load_artifacts`` with a tiny sklearn model + preprocessor that match the expected tensor shape.
+"""
+
+import numpy as np
+import pytest
 from fastapi.testclient import TestClient
-from src.serving.app import app
+from sklearn.dummy import DummyRegressor
+from sklearn.preprocessing import FunctionTransformer
+from src.serving.app import LoadedModel, app
 
 VALID_RECORD = {
     "season": 2,
@@ -15,27 +25,53 @@ VALID_RECORD = {
     "windspeed": 0.20,
 }
 
+# After SelectKBest(k=12) the training pipeline uses 12 columns; keep in sync with configs/params.yaml.
+_N_FEATURES = 12
 
-def test_health_predict_batch_and_metrics():
-    with TestClient(app) as client:
-        health = client.get("/health")
-        assert health.status_code == 200
-        assert health.json()["model_name"] == "bike_share_regressor"
-        assert health.json()["model_version"]
 
-        prediction = client.post("/predict", json=VALID_RECORD)
-        assert prediction.status_code == 200
-        prediction_body = prediction.json()
-        assert isinstance(prediction_body["prediction"], float)
-        assert 0.0 <= prediction_body["confidence"] <= 1.0
-        assert prediction_body["model_version"] == health.json()["model_version"]
+def _fake_load_artifacts() -> LoadedModel:
+    model = DummyRegressor(strategy="constant", constant=100.0)
+    model.fit(np.zeros((5, _N_FEATURES)), np.zeros(5))
 
-        batch = client.post("/predict/batch", json={"records": [VALID_RECORD, VALID_RECORD]})
-        assert batch.status_code == 200
-        batch_body = batch.json()
-        assert len(batch_body["predictions"]) == 2
-        assert all("prediction" in item and "confidence" in item for item in batch_body["predictions"])
+    def _transform(df):  # noqa: ANN001
+        return np.zeros((len(df), _N_FEATURES))
 
-        metrics = client.get("/metrics")
-        assert metrics.status_code == 200
-        assert "bike_inference_total" in metrics.text
+    preprocessor = FunctionTransformer(_transform, validate=False)
+    return LoadedModel(
+        model=model,
+        preprocessor=preprocessor,
+        model_name="bike_share_regressor",
+        model_version="ci-fixture",
+    )
+
+
+@pytest.fixture
+def client(monkeypatch):
+    monkeypatch.setattr("src.serving.app.load_artifacts", _fake_load_artifacts)
+    with TestClient(app) as test_client:
+        yield test_client
+
+
+def test_health_predict_batch_and_metrics(client):
+    health = client.get("/health")
+    assert health.status_code == 200
+    body = health.json()
+    assert body["model_name"] == "bike_share_regressor"
+    assert body["model_version"] == "ci-fixture"
+
+    prediction = client.post("/predict", json=VALID_RECORD)
+    assert prediction.status_code == 200
+    prediction_body = prediction.json()
+    assert isinstance(prediction_body["prediction"], float)
+    assert 0.0 <= prediction_body["confidence"] <= 1.0
+    assert prediction_body["model_version"] == body["model_version"]
+
+    batch = client.post("/predict/batch", json={"records": [VALID_RECORD, VALID_RECORD]})
+    assert batch.status_code == 200
+    batch_body = batch.json()
+    assert len(batch_body["predictions"]) == 2
+    assert all("prediction" in item and "confidence" in item for item in batch_body["predictions"])
+
+    metrics = client.get("/metrics")
+    assert metrics.status_code == 200
+    assert "bike_inference_total" in metrics.text

--- a/tests/unit/test_serving.py
+++ b/tests/unit/test_serving.py
@@ -1,0 +1,63 @@
+from types import SimpleNamespace
+
+import src.serving.app as serving_app
+
+
+def _cfg(model_path="data/splits/model.pkl"):
+    return SimpleNamespace(
+        paths=SimpleNamespace(model=model_path),
+        mlflow=SimpleNamespace(
+            tracking_uri="http://configured-tracking:5000",
+            registered_model_name="bike_share_regressor",
+        ),
+    )
+
+
+def test_load_model_uses_production_registry_uri_and_env_override(monkeypatch):
+    model = object()
+    calls = []
+    tracking_uris = []
+
+    monkeypatch.setenv("MLFLOW_TRACKING_URI", "file:./mlruns")
+    monkeypatch.setattr(serving_app.mlflow, "set_tracking_uri", tracking_uris.append)
+    monkeypatch.setattr(
+        serving_app.mlflow.sklearn,
+        "load_model",
+        lambda uri: calls.append(uri) or model,
+    )
+    monkeypatch.setattr(
+        serving_app.joblib,
+        "load",
+        lambda path: (_ for _ in ()).throw(AssertionError(f"unexpected fallback: {path}")),
+    )
+
+    loaded, version = serving_app._load_model(_cfg())
+
+    assert loaded is model
+    assert version == "Production"
+    assert tracking_uris == ["file:./mlruns"]
+    assert calls == ["models:/bike_share_regressor/Production"]
+
+
+def test_load_model_falls_back_to_local_pickle_when_registry_unavailable(monkeypatch):
+    local_model = object()
+    local_calls = []
+
+    monkeypatch.delenv("MLFLOW_TRACKING_URI", raising=False)
+    monkeypatch.setattr(serving_app.mlflow, "set_tracking_uri", lambda uri: None)
+    monkeypatch.setattr(
+        serving_app.mlflow.sklearn,
+        "load_model",
+        lambda uri: (_ for _ in ()).throw(RuntimeError(f"unavailable: {uri}")),
+    )
+    monkeypatch.setattr(
+        serving_app.joblib,
+        "load",
+        lambda path: local_calls.append(path) or local_model,
+    )
+
+    loaded, version = serving_app._load_model(_cfg("data/splits/model.pkl"))
+
+    assert loaded is local_model
+    assert version == "local"
+    assert local_calls == ["data/splits/model.pkl"]


### PR DESCRIPTION
## Summary
- FastAPI app: `/health`, `/predict`, `/predict/batch` with Pydantic v2 schemas and Prometheus metrics.
- Integration tests for the API; `scripts/validate_model.py` enforces RMSE vs `configs/params.yaml` (`validation.rmse_threshold`).
- `.github/workflows/ci.yml`: ordered jobs `lint` → `test` → `data-validation` → `model-validation` (Ubuntu, Python 3.11, pip cache).
- `tests/data/sample_hour.csv` + Pandera validation tests for the data-validation job.

## Depends on
Merge **PR #N** (Component 2+3) first, **or** rebase this branch onto `main` after that PR lands so the diff stays reviewable.

## Closes
Closes #5 

## Notes
- `model-validation` sets `SKIP_MLFLOW_REGISTRY=1` so CI passes without a live MLflow server; full registry smoke check can be run locally.