### PR TITLE
Chore/GitHub collaboration templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,15 @@
+---
+name: Bug report
+about: Something broken in data, training, registry, serving, or CI
+title: "[BUG] "
+labels: ""
+assignees: ""
+---
+
+## What happened
+
+## Expected behavior
+
+## Steps to reproduce
+
+## Logs / screenshots (if any)

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,10 +1,14 @@
 ---
 name: Bug report
-about: Something broken in data, training, registry, serving, or CI
-title: "[BUG] "
+about: Something broken in data, training, registry, serving, monitoring, or CI
+title: "fix(scope): "
 labels: ""
 assignees: ""
 ---
+
+## Area
+
+<!-- Choose one: data / DVC · preprocessing · training · MLflow · serving · CI · monitoring · other -->
 
 ## What happened
 
@@ -12,4 +16,16 @@ assignees: ""
 
 ## Steps to reproduce
 
-## Logs / screenshots (if any)
+1.
+2.
+3.
+
+## Logs / screenshots
+
+<!-- Tracebacks, CI job link, MLflow UI snippet if relevant -->
+
+## Environment (if useful)
+
+- OS:
+- Python:
+- Branch or commit:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,15 +1,35 @@
 ---
-name: Task / milestone item
-about: Track pipeline work, bugs, or decisions for the team board
-title: "[TASK] "
+name: Task (component / milestone)
+about: Track work that maps to a component, phase, or feature branch
+title: "task(component): "
 labels: ""
 assignees: ""
 ---
 
+## Component / phase
+
+<!-- e.g. Component 2+3 (preprocessing + MLflow), Phase 4–5 (serving + CI), Component 6 (monitoring), Bonus, Docs -->
+
 ## Goal
+
+<!-- What “done” looks like in one paragraph. -->
+
+## Feature branch (when applicable)
+
+<!-- Naming convention: feature/<component-slug> -->
+
+- Branch: `feature/`
 
 ## Scope
 
+- [ ] <!-- bullet tasks -->
+
 ## Definition of done
 
+- [ ] Meets rubric / plan for this component.
+- [ ] Tests and lint pass locally where relevant (`pytest`, `ruff`).
+- [ ] Linked PR uses **Conventional Commits** and will **Closes #** this issue when merged.
+
 ## Notes / links
+
+<!-- Design notes, MLflow run IDs, DVC stage names, etc. -->

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,15 @@
+---
+name: Task / milestone item
+about: Track pipeline work, bugs, or decisions for the team board
+title: "[TASK] "
+labels: ""
+assignees: ""
+---
+
+## Goal
+
+## Scope
+
+## Definition of done
+
+## Notes / links

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,13 +1,38 @@
+## Title (Conventional Commits)
+
+Use the same style as commit messages and PRs on `main`:
+
+`type(scope): short description`
+
+- **Types:** `feat` | `fix` | `chore` | `test` | `docs`
+- **Examples:** `feat(serving): add batch predict endpoint` · `chore(ci): cache pip in workflow` · `fix(dvc): correct train stage deps`
+
+## Branch
+
+- [ ] This PR is from a **short-lived** branch named `feature/<component-slug>` (not from `main` and not long-lived).
+- [ ] Suggested slugs (examples): `component-2-3-train`, `component-4-5-serve-ci`, `component-6-monitoring`, `bonus-docker-prefect`, `component-7-docs`.
+
 ## Summary
 
-<!-- What does this PR change and why? -->
+<!-- What changed and why (1–3 sentences). -->
 
-## Review checklist
+## Related issues
 
-- [ ] Another teammate has reviewed this PR (required before merge)
-- [ ] CI / tests pass locally (`pytest`, `ruff` as applicable)
-- [ ] No secrets or large binaries committed unintentionally
+<!-- Link issues so they close automatically when this merges: -->
 
-## Related Issues
+Closes #
 
-<!-- Link GitHub issues: Fixes #123 -->
+<!-- Other refs: Related # -->
+
+## Pre-merge checklist (team workflow)
+
+- [ ] **At least 1** teammate has **approved** this PR (required).
+- [ ] Merge strategy will be **squash merge** via GitHub (no direct pushes to `main`).
+- [ ] **Branch is up to date** with `main` if branch protection requires it.
+- [ ] **CI:** All required checks are **green** on the latest commit (once branch protection is configured):
+  - `lint`
+  - `test`
+  - `data-validation`
+  - `model-validation`
+- [ ] **Repo hygiene:** No raw data under `data/` (use DVC), no `.env`, venv, or `mlruns/` committed unintentionally.
+- [ ] **Config:** Deliberate updates to `configs/params.yaml`, `dvc.yaml` / `dvc.lock` only when intended.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+## Summary
+
+<!-- What does this PR change and why? -->
+
+## Review checklist
+
+- [ ] Another teammate has reviewed this PR (required before merge)
+- [ ] CI / tests pass locally (`pytest`, `ruff` as applicable)
+- [ ] No secrets or large binaries committed unintentionally
+
+## Related Issues
+
+<!-- Link GitHub issues: Fixes #123 -->


### PR DESCRIPTION
## Summary
Adds GitHub issue templates (bug report + task) and a repository-level pull request template so the team follows one workflow.

## Scope
- `.github/ISSUE_TEMPLATE/` — bug report and task templates aligned with branch naming, Conventional Commits, and the four CI job names.
- `.github/pull_request_template.md` — title format, `feature/<slug>` branches, squash/approval/checklist, `Closes #` guidance.
- `.github/ISSUE_TEMPLATE/config.yml` — blank issues allowed.

## Notes
- No application or ML code changes.
- Safe to merge before or in parallel with feature PRs (Components 2+3, 4+5).

