### PR TITLE
add mlflow cleanup utility and naming guide

### DIFF
--- a/scripts/mlflow_cleanup.py
+++ b/scripts/mlflow_cleanup.py
@@ -1,0 +1,249 @@
+"""
+MLflow cleanup — rename runs, normalize tags, add descriptions.
+
+Usage:
+    python scripts/mlflow_cleanup.py --dry-run
+    python scripts/mlflow_cleanup.py --apply
+    python scripts/mlflow_cleanup.py --apply --experiment-id 886455878294338602
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from datetime import datetime
+
+import mlflow
+from mlflow.entities import ViewType
+from mlflow.tracking import MlflowClient
+
+TRACKING_URI = "http://127.0.0.1:5000"
+DEFAULT_EXPERIMENT_ID = "886455878294338602"
+
+AUTO_NAME_PATTERNS = [
+    r"^[a-z]+-[a-z]+-\d+$",
+    r"^run\d+$",
+    r"^run_\d{4}-\d{2}-\d{2}.*$",
+    r"^\s*$",
+    r"^untitled.*$",
+]
+
+
+def is_auto_generated(name: str | None) -> bool:
+    if not name:
+        return True
+    normalized = name.strip().lower()
+    return any(re.match(pattern, normalized) for pattern in AUTO_NAME_PATTERNS)
+
+
+def infer_stage_and_algo(run) -> tuple[str, str]:  # noqa: ANN001
+    """Infer stage and algorithm from tags/params/metrics/run-name heuristics."""
+    tags = run.data.tags or {}
+    params = run.data.params or {}
+    metrics = run.data.metrics or {}
+    run_name = (run.info.run_name or "").lower()
+
+    stage = tags.get("stage")
+    algo = tags.get("algo") or tags.get("model_type") or tags.get("estimator")
+
+    if not algo:
+        if "n_estimators" in params and "max_depth" in params:
+            algo = "rf" if "criterion" in params else "xgb"
+        elif "num_leaves" in params:
+            algo = "lgbm"
+        elif "learning_rate_init" in params:
+            algo = "mlp"
+        elif "alpha" in params and "fit_intercept" in params:
+            algo = "lr"
+        elif "persistence" in run_name:
+            algo = "persistence"
+        elif "hourly" in run_name and "mean" in run_name:
+            algo = "hourly_mean"
+        elif "drift" in run_name:
+            algo = "check"
+        else:
+            algo = "unknown"
+
+    if not stage:
+        if any(metric.startswith("drift") or "drift" in metric for metric in metrics):
+            stage = "drift"
+        elif "persistence" in run_name or "hourly_mean" in run_name:
+            stage = "baseline"
+        elif "cv_" in "".join(metrics.keys()) or "best_cv_rmse" in metrics:
+            stage = "tune"
+        elif "test_rmse" in metrics or "val_rmse" in metrics:
+            stage = "train"
+        elif "debug" in run_name:
+            stage = "debug"
+        else:
+            stage = "train"
+
+    return stage, algo
+
+
+def short_id(run) -> str:  # noqa: ANN001
+    ts = datetime.fromtimestamp(run.info.start_time / 1000)
+    return ts.strftime("%y%m%d%H")
+
+
+def proposed_name(run) -> str:  # noqa: ANN001
+    stage, algo = infer_stage_and_algo(run)
+    return f"{stage}__{algo}__{short_id(run)}"
+
+
+def _short_git_commit() -> str:
+    try:
+        out = subprocess.check_output(["git", "rev-parse", "--short", "HEAD"], text=True).strip()
+        return out or "unknown"
+    except Exception:
+        return "unknown"
+
+
+def proposed_tags(run) -> dict[str, str]:  # noqa: ANN001
+    stage, algo = infer_stage_and_algo(run)
+    existing_tags = run.data.tags or {}
+    existing_params = run.data.params or {}
+    dataset_hash = (
+        existing_tags.get("dataset_hash")
+        or existing_params.get("dataset_hash")
+        or existing_tags.get("data_hash")
+        or "unknown"
+    )
+    if len(dataset_hash) > 12:
+        dataset_hash = dataset_hash[:12]
+    author = existing_tags.get("author") or os.environ.get("USERNAME") or os.environ.get("USER") or "unknown"
+    git_commit = (
+        existing_tags.get("git_commit")
+        or existing_params.get("git_commit")
+        or _short_git_commit()
+    )
+    return {
+        "stage": stage,
+        "algo": algo,
+        "dataset_hash": str(dataset_hash),
+        "author": str(author),
+        "git_commit": str(git_commit),
+        "cleaned_by": "mlflow_cleanup.py",
+    }
+
+
+def proposed_description(run) -> str | None:  # noqa: ANN001
+    existing = (run.data.tags or {}).get("mlflow.note.content")
+    if existing and len(existing.strip()) > 5:
+        return None
+    params = run.data.params or {}
+    metrics = run.data.metrics or {}
+    _stage, algo = infer_stage_and_algo(run)
+    parts = [f"{algo} run."]
+    if "n_estimators" in params:
+        parts.append(f"trees={params['n_estimators']}")
+    if "max_depth" in params:
+        parts.append(f"depth={params['max_depth']}")
+    if "learning_rate" in params:
+        parts.append(f"lr={params['learning_rate']}")
+    if "test_rmse" in metrics:
+        parts.append(f"test RMSE {metrics['test_rmse']:.2f}")
+    elif "rmse" in metrics:
+        parts.append(f"RMSE {metrics['rmse']:.2f}")
+    return " ".join(parts) if len(parts) > 1 else None
+
+
+def cleanup_experiment(client: MlflowClient, experiment_id: str, apply: bool) -> int:
+    runs = client.search_runs(
+        experiment_ids=[experiment_id],
+        run_view_type=ViewType.ALL,
+        max_results=10000,
+        order_by=["start_time DESC"],
+    )
+
+    print(f"Found {len(runs)} runs in experiment {experiment_id}\n")
+    print(f"{'STATUS':<8} {'OLD NAME':<35} -> {'NEW NAME':<35}  TAGS")
+    print("-" * 120)
+
+    changes = 0
+    for run in runs:
+        old_name = run.info.run_name or "(empty)"
+        new_name = proposed_name(run)
+        new_tags = proposed_tags(run)
+        new_desc = proposed_description(run)
+
+        will_rename = is_auto_generated(old_name) and old_name != new_name
+        existing_tags = run.data.tags or {}
+        will_tag = any(existing_tags.get(k) != v for k, v in new_tags.items())
+
+        if not will_rename and not will_tag and not new_desc:
+            print(f"{'SKIP':<8} {old_name[:34]:<35}   (already clean)")
+            continue
+
+        changes += 1
+        action = "APPLY" if apply else "DRY"
+        target_name = new_name if will_rename else old_name
+        print(f"{action:<8} {old_name[:34]:<35} -> {target_name[:34]:<35}  {new_tags}")
+
+        if not apply:
+            continue
+
+        if will_rename:
+            client.set_tag(run.info.run_id, "mlflow.runName", new_name)
+        for key, value in new_tags.items():
+            client.set_tag(run.info.run_id, key, value)
+        if new_desc:
+            client.set_tag(run.info.run_id, "mlflow.note.content", new_desc)
+
+    print("-" * 120)
+    print(f"\n{'Applied' if apply else 'Would apply'} {changes} change(s).")
+    if not apply:
+        print("\nRe-run with --apply to commit these changes.")
+    return changes
+
+
+def maybe_rename_experiment(client: MlflowClient, experiment_id: str, apply: bool) -> None:
+    exp = client.get_experiment(experiment_id)
+    current = exp.name
+    proposed = "bike_share_training"
+    if current == proposed:
+        print(f"Experiment name already clean: {current!r}")
+        return
+    print(f"\nExperiment name: {current!r} -> {proposed!r}")
+    if apply:
+        client.rename_experiment(experiment_id, proposed)
+        print("Renamed.")
+    else:
+        print("(dry run — pass --apply to rename)")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--tracking-uri", default=TRACKING_URI)
+    parser.add_argument("--experiment-id", default=DEFAULT_EXPERIMENT_ID)
+    parser.add_argument("--apply", action="store_true", help="Actually apply changes")
+    parser.add_argument("--dry-run", action="store_true", help="Show changes only (default)")
+    parser.add_argument(
+        "--rename-experiment",
+        action="store_true",
+        help="Also rename the experiment itself",
+    )
+    args = parser.parse_args()
+
+    apply = args.apply and not args.dry_run
+    mlflow.set_tracking_uri(args.tracking_uri)
+    client = MlflowClient(tracking_uri=args.tracking_uri)
+
+    try:
+        client.get_experiment(args.experiment_id)
+    except Exception as exc:
+        print(f"Cannot reach experiment {args.experiment_id} at {args.tracking_uri}")
+        print(f"Is the MLflow server running? Error: {exc}")
+        sys.exit(1)
+
+    cleanup_experiment(client, args.experiment_id, apply=apply)
+
+    if args.rename_experiment:
+        maybe_rename_experiment(client, args.experiment_id, apply=apply)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/mlflow_naming.md
+++ b/scripts/mlflow_naming.md
@@ -1,0 +1,37 @@
+## MLflow naming convention — Bike Sharing project
+
+### Experiment names
+Format: `bike_share_<purpose>`
+Examples:
+- bike_share_training       — model training runs
+- bike_share_tuning         — hyperparameter sweeps
+- bike_share_drift          — Evidently drift reports
+- bike_share_baselines      — persistence and hourly mean baselines
+
+### Run names
+Format: `<stage>__<algo_or_purpose>__<short_id>`
+
+Where:
+- stage: one of [train, tune, baseline, eval, drift, debug]
+- algo: short model identifier (rf, xgb, lgbm, lr, persistence, hourly_mean)
+  or purpose for non-training runs (drift_check, sanity)
+- short_id: 8-char timestamp YYMMDDHH or version tag (v1, v2, exp03)
+
+Examples:
+- train__xgb__25050610
+- baseline__persistence__25050610
+- tune__rf__exp03
+- drift__check__25050612
+- eval__xgb_v1__final_test
+
+### Required tags on every run
+- stage          — same as in the name
+- algo           — same as in the name
+- dataset_hash   — first 12 chars of SHA-256 of the input data
+- author         — student's identifier (e.g. "ali")
+- git_commit     — short hash, if available
+
+### Run descriptions
+Every run gets a one-line `mlflow.note.content` describing what was tested.
+Bad: "first try"
+Good: "XGBoost 500 trees, max_depth=8, lr=0.05, all features. Beats persistence by 23% RMSE."


### PR DESCRIPTION
## Title (Conventional Commits)

Use the same style as commit messages and PRs on `main`:

`type(scope): short description`

- **Types:** `feat` | `fix` | `chore` | `test` | `docs`
- **Examples:** `feat(serving): add batch predict endpoint` · `chore(ci): cache pip in workflow` · `fix(dvc): correct train stage deps` · `docs(evidence): update technical report screenshots`

## Branch

- [ ] This PR is from a **short-lived** branch named `feature/<component-slug>` (not from `main` and not long-lived).
- [ ] Suggested slugs (examples): `component-2-3-train`, `component-4-5-serve-ci`, `component-6-monitoring`, `bonus-docker-prefect`, `component-7-docs`.

## Summary

<!-- What changed and why (1–3 sentences). -->

## How to test

<!-- e.g. commands, Docker, or “N/A (docs-only)”. -->

## Docs / evidence (if applicable)

<!-- e.g. `docs/technical_report.md`, `docs/screenshots/`, or “N/A”. -->

## Related issues

<!-- Link issues so they close automatically when this merges: -->

Closes #

<!-- Other refs: Related # -->

## Pre-merge checklist (team workflow)

- [ ] **At least 1** teammate has **approved** this PR (required).
- [ ] Merge strategy will be **squash merge** via GitHub (no direct pushes to `main`).
- [ ] **Branch is up to date** with `main` if branch protection requires it.
- [ ] **CI:** All required checks are **green** on the latest commit (once branch protection is configured):
  - `lint`
  - `test`
  - `data-validation`
  - `model-validation`
- [ ] **Repo hygiene:** No raw data under `data/` (use DVC), no `.env`, local venvs (e.g. `.venv/`, `.venv_strict/`), or experiment dirs such as `mlruns/` / `mlruns_local_strict/` committed unintentionally.
- [ ] **Config:** Deliberate updates to `configs/params.yaml`, `dvc.yaml` / `dvc.lock` only when intended.
